### PR TITLE
Added 'Name' tags for NACLs, Routing Tables, Subnets, and VPC. Added …

### DIFF
--- a/templates/aws-vpc.template
+++ b/templates/aws-vpc.template
@@ -1,2144 +1,2488 @@
 {
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "This template creates a Multi-AZ, multi-subnet VPC infrastructure with managed NAT gateways in the public subnet for each Availability Zone. You can also create additional private subnets with dedicated custom network access control lists (ACLs). If you deploy the Quick Start in a region that doesn’t support NAT gateways, NAT instances are deployed instead. **WARNING** This template creates AWS resources. You will be billed for the AWS resources used if you create a stack from this template. QS(0027)",
-    "Metadata": {
-        "AWS::CloudFormation::Interface": {
-            "ParameterGroups": [
-                {
-                    "Label": {
-                        "default": "Availability Zone Configuration"
-                    },
-                    "Parameters": [
-                        "AvailabilityZones",
-                        "NumberOfAZs"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Network Configuration"
-                    },
-                    "Parameters": [
-                        "VPCCIDR",
-                        "PrivateSubnet1ACIDR",
-                        "PrivateSubnet2ACIDR",
-                        "PrivateSubnet3ACIDR",
-                        "PrivateSubnet4ACIDR",
-                        "PublicSubnet1CIDR",
-                        "PublicSubnet2CIDR",
-                        "PublicSubnet3CIDR",
-                        "PublicSubnet4CIDR",
-                        "CreateAdditionalPrivateSubnets",
-                        "PrivateSubnet1BCIDR",
-                        "PrivateSubnet2BCIDR",
-                        "PrivateSubnet3BCIDR",
-                        "PrivateSubnet4BCIDR"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Amazon EC2 Configuration"
-                    },
-                    "Parameters": [
-                        "KeyPairName",
-                        "NATInstanceType"
-                    ]
-                }
-            ],
-            "ParameterLabels": {
-                "AvailabilityZones": {
-                    "default": "Availability Zones"
-                },
-                "CreateAdditionalPrivateSubnets": {
-                    "default": "Create additional private subnets with dedicated network ACLs"
-                },
-                "KeyPairName": {
-                    "default": "Key pair name"
-                },
-                "NATInstanceType": {
-                    "default": "NAT instance type"
-                },
-                "NumberOfAZs": {
-                    "default": "Number of Availability Zones"
-                },
-                "PrivateSubnet1ACIDR": {
-                    "default": "Private subnet 1A CIDR"
-                },
-                "PrivateSubnet1BCIDR": {
-                    "default": "Private subnet 1B with dedicated network ACL CIDR"
-                },
-                "PrivateSubnet2ACIDR": {
-                    "default": "Private subnet 2A CIDR"
-                },
-                "PrivateSubnet2BCIDR": {
-                    "default": "Private subnet 2B with dedicated network ACL CIDR"
-                },
-                "PrivateSubnet3ACIDR": {
-                    "default": "Private subnet 3A CIDR"
-                },
-                "PrivateSubnet3BCIDR": {
-                    "default": "Private subnet 3B with dedicated network ACL CIDR"
-                },
-                "PrivateSubnet4ACIDR": {
-                    "default": "Private subnet 4A CIDR"
-                },
-                "PrivateSubnet4BCIDR": {
-                    "default": "Private subnet 4B with dedicated network ACL CIDR"
-                },
-                "PublicSubnet1CIDR": {
-                    "default": "Public subnet 1 CIDR"
-                },
-                "PublicSubnet2CIDR": {
-                    "default": "Public subnet 2 CIDR"
-                },
-                "PublicSubnet3CIDR": {
-                    "default": "Public subnet 3 CIDR"
-                },
-                "PublicSubnet4CIDR": {
-                    "default": "Public subnet 4 CIDR"
-                },
-                "VPCCIDR": {
-                    "default": "VPC CIDR"
-                }
-            }
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "This template creates a Multi-AZ, multi-subnet VPC infrastructure with managed NAT gateways in the public subnet for each Availability Zone. You can also create additional private subnets with dedicated custom network access control lists (ACLs). If you deploy the Quick Start in a region that doesn’t support NAT gateways, NAT instances are deployed instead. **WARNING** This template creates AWS resources. You will be billed for the AWS resources used if you create a stack from this template. QS(0027)",
+  "Metadata": {
+    "AWS::CloudFormation::Interface": {
+      "ParameterGroups": [
+        {
+          "Label": {
+            "default": "Availability Zone Configuration"
+          },
+          "Parameters": [
+            "AvailabilityZones",
+            "NumberOfAZs"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Network Configuration"
+          },
+          "Parameters": [
+            "VPCName",
+            "VPCCIDR",
+            "PrivateSubnetANamePrefix",
+            "PrivateSubnet1ACIDR",
+            "PrivateSubnet2ACIDR",
+            "PrivateSubnet3ACIDR",
+            "PrivateSubnet4ACIDR",
+            "PublicSubnetNamePrefix",
+            "PublicSubnet1CIDR",
+            "PublicSubnet2CIDR",
+            "PublicSubnet3CIDR",
+            "PublicSubnet4CIDR",
+            "CreateAdditionalPrivateSubnets",
+            "PrivateSubnetBNamePrefix",
+            "PrivateSubnet1BCIDR",
+            "PrivateSubnet2BCIDR",
+            "PrivateSubnet3BCIDR",
+            "PrivateSubnet4BCIDR"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Amazon EC2 Configuration"
+          },
+          "Parameters": [
+            "KeyPairName",
+            "NATInstanceType"
+          ]
         }
-    },
-    "Parameters": {
+      ],
+      "ParameterLabels": {
         "AvailabilityZones": {
-            "Description": "List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved.",
-            "Type": "List<AWS::EC2::AvailabilityZone::Name>"
+          "default": "Availability Zones"
         },
         "CreateAdditionalPrivateSubnets": {
-            "AllowedValues": [
-                "true",
-                "false"
-            ],
-            "Default": "false",
-            "Description": "Set to true to create a network ACL protected subnet in each Availability Zone. If false, the CIDR parameters for those subnets will be ignored.",
-            "Type": "String"
+          "default": "Create additional private subnets with dedicated network ACLs"
         },
         "KeyPairName": {
-            "Description": "Public/private key pairs allow you to securely connect to your NAT instance after it launches. This is used only if the region does not support NAT gateways.",
-            "Type": "AWS::EC2::KeyPair::KeyName"
+          "default": "Key pair name"
         },
         "NATInstanceType": {
-            "AllowedValues": [
-                "t2.nano",
-                "t2.micro",
-                "t2.small",
-                "t2.medium",
-                "t2.large",
-                "m3.medium",
-                "m3.large",
-                "m4.large"
-            ],
-            "Default": "t2.small",
-            "Description": "Amazon EC2 instance type for the NAT instances. This is used only if the region does not support NAT gateways.",
-            "Type": "String"
+          "default": "NAT instance type"
         },
         "NumberOfAZs": {
-            "AllowedValues": [
-                "2",
-                "3",
-                "4"
-            ],
-            "Default": "2",
-            "Description": "Number of Availability Zones to use in the VPC. This must match your selections in the list of Availability Zones parameter.",
-            "Type": "String"
+          "default": "Number of Availability Zones"
         },
         "PrivateSubnet1ACIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.0.0/19",
-            "Description": "CIDR block for private subnet 1A located in Availability Zone 1",
-            "Type": "String"
+          "default": "Private subnet 1A CIDR"
         },
         "PrivateSubnet1BCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.48.0/21",
-            "Description": "CIDR block for private subnet 1B with dedicated network ACL located in Availability Zone 1",
-            "Type": "String"
+          "default": "Private subnet 1B with dedicated network ACL CIDR"
         },
         "PrivateSubnet2ACIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.64.0/19",
-            "Description": "CIDR block for private subnet 2A located in Availability Zone 2",
-            "Type": "String"
+          "default": "Private subnet 2A CIDR"
         },
         "PrivateSubnet2BCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.112.0/21",
-            "Description": "CIDR block for private subnet 2B with dedicated network ACL located in Availability Zone 2",
-            "Type": "String"
+          "default": "Private subnet 2B with dedicated network ACL CIDR"
         },
         "PrivateSubnet3ACIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.128.0/19",
-            "Description": "CIDR block for private subnet 3A located in Availability Zone 3",
-            "Type": "String"
+          "default": "Private subnet 3A CIDR"
         },
         "PrivateSubnet3BCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.176.0/21",
-            "Description": "CIDR block for private subnet 3B with dedicated network ACL located in Availability Zone 3",
-            "Type": "String"
+          "default": "Private subnet 3B with dedicated network ACL CIDR"
         },
         "PrivateSubnet4ACIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.192.0/19",
-            "Description": "CIDR block for private subnet 4A located in Availability Zone 4",
-            "Type": "String"
+          "default": "Private subnet 4A CIDR"
         },
         "PrivateSubnet4BCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.240.0/21",
-            "Description": "CIDR block for private subnet 4B with dedicated network ACL located in Availability Zone 4",
-            "Type": "String"
+          "default": "Private subnet 4B with dedicated network ACL CIDR"
         },
         "PublicSubnet1CIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.32.0/20",
-            "Description": "CIDR block for the public DMZ subnet 1 located in Availability Zone 1",
-            "Type": "String"
+          "default": "Public subnet 1 CIDR"
         },
         "PublicSubnet2CIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.96.0/20",
-            "Description": "CIDR block for the public DMZ subnet 2 located in Availability Zone 2",
-            "Type": "String"
+          "default": "Public subnet 2 CIDR"
         },
         "PublicSubnet3CIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.160.0/20",
-            "Description": "CIDR block for the public DMZ subnet 3 located in Availability Zone 3",
-            "Type": "String"
+          "default": "Public subnet 3 CIDR"
         },
         "PublicSubnet4CIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.224.0/20",
-            "Description": "CIDR block for the public DMZ subnet 4 located in Availability Zone 4",
-            "Type": "String"
+          "default": "Public subnet 4 CIDR"
         },
         "VPCCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "Default": "10.0.0.0/16",
-            "Description": "CIDR block for the VPC",
-            "Type": "String"
+          "default": "VPC CIDR"
         }
-    },
-    "Mappings": {
-        "AWSAMIRegionMap": {
-            "AMI": {
-                "AWSNAT": "amzn-ami-vpc-nat-hvm-2016.03.3.x86_64-ebs"
-            },
-            "ap-northeast-1": {
-                "AWSNAT": "ami-2443b745"
-            },
-            "ap-northeast-2": {
-                "AWSNAT": "ami-d14388bf"
-            },
-            "ap-south-1": {
-                "AWSNAT": "ami-e2b9d38d"
-            },
-            "ap-southeast-1": {
-                "AWSNAT": "ami-a79b49c4"
-            },
-            "ap-southeast-2": {
-                "AWSNAT": "ami-53371f30"
-            },
-            "eu-central-1": {
-                "AWSNAT": "ami-5825cd37"
-            },
-            "eu-west-1": {
-                "AWSNAT": "ami-a8dd45db"
-            },
-            "sa-east-1": {
-                "AWSNAT": "ami-9336bcff"
-            },
-            "us-east-1": {
-                "AWSNAT": "ami-4868ab25"
-            },
-            "us-west-1": {
-                "AWSNAT": "ami-004b0f60"
-            },
-            "us-west-2": {
-                "AWSNAT": "ami-a275b1c2"
-            }
-        }
-    },
-    "Conditions": {
-        "3AZCondition": {
-            "Fn::Or": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "NumberOfAZs"
-                        },
-                        "3"
-                    ]
-                },
-                {
-                    "Condition": "4AZCondition"
-                }
-            ]
-        },
-        "4AZCondition": {
-            "Fn::Equals": [
-                {
-                    "Ref": "NumberOfAZs"
-                },
-                "4"
-            ]
-        },
-        "AdditionalPrivateSubnetsCondition": {
-            "Fn::Equals": [
-                {
-                    "Ref": "CreateAdditionalPrivateSubnets"
-                },
-                "true"
-            ]
-        },
-        "AdditionalPrivateSubnets&3AZCondition": {
-            "Fn::And": [
-                {
-                    "Condition": "AdditionalPrivateSubnetsCondition"
-                },
-                {
-                    "Condition": "3AZCondition"
-                }
-            ]
-        },
-        "AdditionalPrivateSubnets&4AZCondition": {
-            "Fn::And": [
-                {
-                    "Condition": "AdditionalPrivateSubnetsCondition"
-                },
-                {
-                    "Condition": "4AZCondition"
-                }
-            ]
-        },
-        "NATInstanceCondition": {
-            "Fn::Or": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        "sa-east-1"
-                    ]
-                },
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        "us-gov-west-1"
-                    ]
-                },
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        "cn-north-1"
-                    ]
-                }
-            ]
-        },
-        "NATGatewayCondition": {
-            "Fn::Not": [
-                {
-                    "Condition": "NATInstanceCondition"
-                }
-            ]
-        },
-        "NATInstance&3AZCondition": {
-            "Fn::And": [
-                {
-                    "Condition": "NATInstanceCondition"
-                },
-                {
-                    "Condition": "3AZCondition"
-                }
-            ]
-        },
-        "NATInstance&4AZCondition": {
-            "Fn::And": [
-                {
-                    "Condition": "NATInstanceCondition"
-                },
-                {
-                    "Condition": "4AZCondition"
-                }
-            ]
-        },
-        "NATGateway&3AZCondition": {
-            "Fn::And": [
-                {
-                    "Condition": "NATGatewayCondition"
-                },
-                {
-                    "Condition": "3AZCondition"
-                }
-            ]
-        },
-        "NATGateway&4AZCondition": {
-            "Fn::And": [
-                {
-                    "Condition": "NATGatewayCondition"
-                },
-                {
-                    "Condition": "4AZCondition"
-                }
-            ]
-        }
-    },
-    "Resources": {
-        "DHCPOptions": {
-            "Type": "AWS::EC2::DHCPOptions",
-            "Properties": {
-                "DomainNameServers": [
-                    "AmazonProvidedDNS"
-                ]
-            }
-        },
-        "VPC": {
-            "Type": "AWS::EC2::VPC",
-            "Properties": {
-                "CidrBlock": {
-                    "Ref": "VPCCIDR"
-                }
-            }
-        },
-        "VPCDHCPOptionsAssociation": {
-            "Type": "AWS::EC2::VPCDHCPOptionsAssociation",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "DhcpOptionsId": {
-                    "Ref": "DHCPOptions"
-                }
-            }
-        },
-        "InternetGateway": {
-            "Type": "AWS::EC2::InternetGateway",
-            "Properties": {
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Public"
-                    }
-                ]
-            }
-        },
-        "VPCGatewayAttachment": {
-            "Type": "AWS::EC2::VPCGatewayAttachment",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "InternetGatewayId": {
-                    "Ref": "InternetGateway"
-                }
-            }
-        },
-        "PrivateSubnet1A": {
-            "Type": "AWS::EC2::Subnet",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "CidrBlock": {
-                    "Ref": "PrivateSubnet1ACIDR"
-                },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "0",
-                        {
-                            "Ref": "AvailabilityZones"
-                        }
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 1A"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet1B": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::Subnet",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "CidrBlock": {
-                    "Ref": "PrivateSubnet1BCIDR"
-                },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "0",
-                        {
-                            "Ref": "AvailabilityZones"
-                        }
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 1B"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet2A": {
-            "Type": "AWS::EC2::Subnet",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "CidrBlock": {
-                    "Ref": "PrivateSubnet2ACIDR"
-                },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "1",
-                        {
-                            "Ref": "AvailabilityZones"
-                        }
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 2A"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet2B": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::Subnet",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "CidrBlock": {
-                    "Ref": "PrivateSubnet2BCIDR"
-                },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "1",
-                        {
-                            "Ref": "AvailabilityZones"
-                        }
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 2B"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet3A": {
-            "Condition": "3AZCondition",
-            "Type": "AWS::EC2::Subnet",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "CidrBlock": {
-                    "Ref": "PrivateSubnet3ACIDR"
-                },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "2",
-                        {
-                            "Ref": "AvailabilityZones"
-                        }
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 3A"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet3B": {
-            "Condition": "AdditionalPrivateSubnets&3AZCondition",
-            "Type": "AWS::EC2::Subnet",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "CidrBlock": {
-                    "Ref": "PrivateSubnet3BCIDR"
-                },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "2",
-                        {
-                            "Ref": "AvailabilityZones"
-                        }
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 3B"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet4A": {
-            "Condition": "4AZCondition",
-            "Type": "AWS::EC2::Subnet",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "CidrBlock": {
-                    "Ref": "PrivateSubnet4ACIDR"
-                },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "3",
-                        {
-                            "Ref": "AvailabilityZones"
-                        }
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 4A"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet4B": {
-            "Condition": "AdditionalPrivateSubnets&4AZCondition",
-            "Type": "AWS::EC2::Subnet",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "CidrBlock": {
-                    "Ref": "PrivateSubnet4BCIDR"
-                },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "3",
-                        {
-                            "Ref": "AvailabilityZones"
-                        }
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 4B"
-                    }
-                ]
-            }
-        },
-        "PublicSubnet1": {
-            "Type": "AWS::EC2::Subnet",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "CidrBlock": {
-                    "Ref": "PublicSubnet1CIDR"
-                },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "0",
-                        {
-                            "Ref": "AvailabilityZones"
-                        }
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Public"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Public subnet 1"
-                    }
-                ]
-            }
-        },
-        "PublicSubnet2": {
-            "Type": "AWS::EC2::Subnet",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "CidrBlock": {
-                    "Ref": "PublicSubnet2CIDR"
-                },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "1",
-                        {
-                            "Ref": "AvailabilityZones"
-                        }
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Public"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Public subnet 2"
-                    }
-                ]
-            }
-        },
-        "PublicSubnet3": {
-            "Condition": "3AZCondition",
-            "Type": "AWS::EC2::Subnet",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "CidrBlock": {
-                    "Ref": "PublicSubnet3CIDR"
-                },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "2",
-                        {
-                            "Ref": "AvailabilityZones"
-                        }
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Public"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Public subnet 3"
-                    }
-                ]
-            }
-        },
-        "PublicSubnet4": {
-            "Condition": "4AZCondition",
-            "Type": "AWS::EC2::Subnet",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "CidrBlock": {
-                    "Ref": "PublicSubnet4CIDR"
-                },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "3",
-                        {
-                            "Ref": "AvailabilityZones"
-                        }
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Public"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Public subnet 4"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet1ARouteTable": {
-            "Type": "AWS::EC2::RouteTable",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 1A"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet1ARoute": {
-            "Type": "AWS::EC2::Route",
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet1ARouteTable"
-                },
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "InstanceId": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "NATInstance1"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "NatGatewayId": {
-                    "Fn::If": [
-                        "NATGatewayCondition",
-                        {
-                            "Ref": "NATGateway1"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                }
-            }
-        },
-        "PrivateSubnet1ARouteTableAssociation": {
-            "Type": "AWS::EC2::SubnetRouteTableAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PrivateSubnet1A"
-                },
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet1ARouteTable"
-                }
-            }
-        },
-        "PrivateSubnet2ARouteTable": {
-            "Type": "AWS::EC2::RouteTable",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 2A"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet2ARoute": {
-            "Type": "AWS::EC2::Route",
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet2ARouteTable"
-                },
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "InstanceId": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "NATInstance2"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "NatGatewayId": {
-                    "Fn::If": [
-                        "NATGatewayCondition",
-                        {
-                            "Ref": "NATGateway2"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                }
-            }
-        },
-        "PrivateSubnet2ARouteTableAssociation": {
-            "Type": "AWS::EC2::SubnetRouteTableAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PrivateSubnet2A"
-                },
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet2ARouteTable"
-                }
-            }
-        },
-        "PrivateSubnet3ARouteTable": {
-            "Condition": "3AZCondition",
-            "Type": "AWS::EC2::RouteTable",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 3A"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet3ARoute": {
-            "Condition": "3AZCondition",
-            "Type": "AWS::EC2::Route",
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet3ARouteTable"
-                },
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "InstanceId": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "NATInstance3"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "NatGatewayId": {
-                    "Fn::If": [
-                        "NATGatewayCondition",
-                        {
-                            "Ref": "NATGateway3"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                }
-            }
-        },
-        "PrivateSubnet3ARouteTableAssociation": {
-            "Condition": "3AZCondition",
-            "Type": "AWS::EC2::SubnetRouteTableAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PrivateSubnet3A"
-                },
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet3ARouteTable"
-                }
-            }
-        },
-        "PrivateSubnet4ARouteTable": {
-            "Condition": "4AZCondition",
-            "Type": "AWS::EC2::RouteTable",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 4A"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet4ARoute": {
-            "Condition": "4AZCondition",
-            "Type": "AWS::EC2::Route",
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet4ARouteTable"
-                },
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "InstanceId": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "NATInstance4"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "NatGatewayId": {
-                    "Fn::If": [
-                        "NATGatewayCondition",
-                        {
-                            "Ref": "NATGateway4"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                }
-            }
-        },
-        "PrivateSubnet4ARouteTableAssociation": {
-            "Condition": "4AZCondition",
-            "Type": "AWS::EC2::SubnetRouteTableAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PrivateSubnet4A"
-                },
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet4ARouteTable"
-                }
-            }
-        },
-        "PrivateSubnet1BRouteTable": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::RouteTable",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 1B"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet1BRoute": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::Route",
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet1BRouteTable"
-                },
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "InstanceId": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "NATInstance1"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "NatGatewayId": {
-                    "Fn::If": [
-                        "NATGatewayCondition",
-                        {
-                            "Ref": "NATGateway1"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                }
-            }
-        },
-        "PrivateSubnet1BRouteTableAssociation": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::SubnetRouteTableAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PrivateSubnet1B"
-                },
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet1BRouteTable"
-                }
-            }
-        },
-        "PrivateSubnet1BNetworkAcl": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::NetworkAcl",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "NACL Protected"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "NACL Protected subnet 1"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet1BNetworkAclEntryInbound": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::NetworkAclEntry",
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
-                "NetworkAclId": {
-                    "Ref": "PrivateSubnet1BNetworkAcl"
-                },
-                "Protocol": "-1",
-                "RuleAction": "allow",
-                "RuleNumber": "100"
-            }
-        },
-        "PrivateSubnet1BNetworkAclEntryOutbound": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::NetworkAclEntry",
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "true",
-                "NetworkAclId": {
-                    "Ref": "PrivateSubnet1BNetworkAcl"
-                },
-                "Protocol": "-1",
-                "RuleAction": "allow",
-                "RuleNumber": "100"
-            }
-        },
-        "PrivateSubnet1BNetworkAclAssociation": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::SubnetNetworkAclAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PrivateSubnet1B"
-                },
-                "NetworkAclId": {
-                    "Ref": "PrivateSubnet1BNetworkAcl"
-                }
-            }
-        },
-        "PrivateSubnet2BRouteTable": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::RouteTable",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 2B"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet2BRoute": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::Route",
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet2BRouteTable"
-                },
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "InstanceId": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "NATInstance2"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "NatGatewayId": {
-                    "Fn::If": [
-                        "NATGatewayCondition",
-                        {
-                            "Ref": "NATGateway2"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                }
-            }
-        },
-        "PrivateSubnet2BRouteTableAssociation": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::SubnetRouteTableAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PrivateSubnet2B"
-                },
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet2BRouteTable"
-                }
-            }
-        },
-        "PrivateSubnet2BNetworkAcl": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::NetworkAcl",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "NACL Protected"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "NACL Protected subnet 2"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet2BNetworkAclEntryInbound": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::NetworkAclEntry",
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
-                "NetworkAclId": {
-                    "Ref": "PrivateSubnet2BNetworkAcl"
-                },
-                "Protocol": "-1",
-                "RuleAction": "allow",
-                "RuleNumber": "100"
-            }
-        },
-        "PrivateSubnet2BNetworkAclEntryOutbound": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::NetworkAclEntry",
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "true",
-                "NetworkAclId": {
-                    "Ref": "PrivateSubnet2BNetworkAcl"
-                },
-                "Protocol": "-1",
-                "RuleAction": "allow",
-                "RuleNumber": "100"
-            }
-        },
-        "PrivateSubnet2BNetworkAclAssociation": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Type": "AWS::EC2::SubnetNetworkAclAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PrivateSubnet2B"
-                },
-                "NetworkAclId": {
-                    "Ref": "PrivateSubnet2BNetworkAcl"
-                }
-            }
-        },
-        "PrivateSubnet3BRouteTable": {
-            "Condition": "AdditionalPrivateSubnets&3AZCondition",
-            "Type": "AWS::EC2::RouteTable",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 3B"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet3BRoute": {
-            "Condition": "AdditionalPrivateSubnets&3AZCondition",
-            "Type": "AWS::EC2::Route",
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet3BRouteTable"
-                },
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "InstanceId": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "NATInstance3"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "NatGatewayId": {
-                    "Fn::If": [
-                        "NATGatewayCondition",
-                        {
-                            "Ref": "NATGateway3"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                }
-            }
-        },
-        "PrivateSubnet3BRouteTableAssociation": {
-            "Condition": "AdditionalPrivateSubnets&3AZCondition",
-            "Type": "AWS::EC2::SubnetRouteTableAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PrivateSubnet3B"
-                },
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet3BRouteTable"
-                }
-            }
-        },
-        "PrivateSubnet3BNetworkAcl": {
-            "Condition": "AdditionalPrivateSubnets&3AZCondition",
-            "Type": "AWS::EC2::NetworkAcl",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "NACL Protected"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "NACL Protected subnet 3"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet3BNetworkAclEntryInbound": {
-            "Condition": "AdditionalPrivateSubnets&3AZCondition",
-            "Type": "AWS::EC2::NetworkAclEntry",
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
-                "NetworkAclId": {
-                    "Ref": "PrivateSubnet3BNetworkAcl"
-                },
-                "Protocol": "-1",
-                "RuleAction": "allow",
-                "RuleNumber": "100"
-            }
-        },
-        "PrivateSubnet3BNetworkAclEntryOutbound": {
-            "Condition": "AdditionalPrivateSubnets&3AZCondition",
-            "Type": "AWS::EC2::NetworkAclEntry",
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "true",
-                "NetworkAclId": {
-                    "Ref": "PrivateSubnet3BNetworkAcl"
-                },
-                "Protocol": "-1",
-                "RuleAction": "allow",
-                "RuleNumber": "100"
-            }
-        },
-        "PrivateSubnet3BNetworkAclAssociation": {
-            "Condition": "AdditionalPrivateSubnets&3AZCondition",
-            "Type": "AWS::EC2::SubnetNetworkAclAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PrivateSubnet3B"
-                },
-                "NetworkAclId": {
-                    "Ref": "PrivateSubnet3BNetworkAcl"
-                }
-            }
-        },
-        "PrivateSubnet4BRouteTable": {
-            "Condition": "AdditionalPrivateSubnets&4AZCondition",
-            "Type": "AWS::EC2::RouteTable",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "Private subnet 4B"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet4BRoute": {
-            "Condition": "AdditionalPrivateSubnets&4AZCondition",
-            "Type": "AWS::EC2::Route",
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet4BRouteTable"
-                },
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "InstanceId": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "NATInstance4"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "NatGatewayId": {
-                    "Fn::If": [
-                        "NATGatewayCondition",
-                        {
-                            "Ref": "NATGateway4"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                }
-            }
-        },
-        "PrivateSubnet4BRouteTableAssociation": {
-            "Condition": "AdditionalPrivateSubnets&4AZCondition",
-            "Type": "AWS::EC2::SubnetRouteTableAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PrivateSubnet4B"
-                },
-                "RouteTableId": {
-                    "Ref": "PrivateSubnet4BRouteTable"
-                }
-            }
-        },
-        "PrivateSubnet4BNetworkAcl": {
-            "Condition": "AdditionalPrivateSubnets&4AZCondition",
-            "Type": "AWS::EC2::NetworkAcl",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "NACL Protected"
-                    },
-                    {
-                        "Key": "Role",
-                        "Value": "NACL Protected subnet 4"
-                    }
-                ]
-            }
-        },
-        "PrivateSubnet4BNetworkAclEntryInbound": {
-            "Condition": "AdditionalPrivateSubnets&4AZCondition",
-            "Type": "AWS::EC2::NetworkAclEntry",
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
-                "NetworkAclId": {
-                    "Ref": "PrivateSubnet4BNetworkAcl"
-                },
-                "Protocol": "-1",
-                "RuleAction": "allow",
-                "RuleNumber": "100"
-            }
-        },
-        "PrivateSubnet4BNetworkAclEntryOutbound": {
-            "Condition": "AdditionalPrivateSubnets&4AZCondition",
-            "Type": "AWS::EC2::NetworkAclEntry",
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "true",
-                "NetworkAclId": {
-                    "Ref": "PrivateSubnet4BNetworkAcl"
-                },
-                "Protocol": "-1",
-                "RuleAction": "allow",
-                "RuleNumber": "100"
-            }
-        },
-        "PrivateSubnet4BNetworkAclAssociation": {
-            "Condition": "AdditionalPrivateSubnets&4AZCondition",
-            "Type": "AWS::EC2::SubnetNetworkAclAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PrivateSubnet4B"
-                },
-                "NetworkAclId": {
-                    "Ref": "PrivateSubnet4BNetworkAcl"
-                }
-            }
-        },
-        "PublicSubnetRouteTable": {
-            "Type": "AWS::EC2::RouteTable",
-            "Properties": {
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Network",
-                        "Value": "Public"
-                    }
-                ]
-            }
-        },
-        "PublicSubnetRoute": {
-            "Type": "AWS::EC2::Route",
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PublicSubnetRouteTable"
-                },
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "GatewayId": {
-                    "Ref": "InternetGateway"
-                }
-            }
-        },
-        "PublicSubnet1RouteTableAssociation": {
-            "Type": "AWS::EC2::SubnetRouteTableAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PublicSubnet1"
-                },
-                "RouteTableId": {
-                    "Ref": "PublicSubnetRouteTable"
-                }
-            }
-        },
-        "PublicSubnet2RouteTableAssociation": {
-            "Type": "AWS::EC2::SubnetRouteTableAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PublicSubnet2"
-                },
-                "RouteTableId": {
-                    "Ref": "PublicSubnetRouteTable"
-                }
-            }
-        },
-        "PublicSubnet3RouteTableAssociation": {
-            "Condition": "3AZCondition",
-            "Type": "AWS::EC2::SubnetRouteTableAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PublicSubnet3"
-                },
-                "RouteTableId": {
-                    "Ref": "PublicSubnetRouteTable"
-                }
-            }
-        },
-        "PublicSubnet4RouteTableAssociation": {
-            "Condition": "4AZCondition",
-            "Type": "AWS::EC2::SubnetRouteTableAssociation",
-            "Properties": {
-                "SubnetId": {
-                    "Ref": "PublicSubnet4"
-                },
-                "RouteTableId": {
-                    "Ref": "PublicSubnetRouteTable"
-                }
-            }
-        },
-        "NAT1EIP": {
-            "Type": "AWS::EC2::EIP",
-            "Properties": {
-                "Domain": "vpc",
-                "InstanceId": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "NATInstance1"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                }
-            }
-        },
-        "NAT2EIP": {
-            "Type": "AWS::EC2::EIP",
-            "Properties": {
-                "Domain": "vpc",
-                "InstanceId": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "NATInstance2"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                }
-            }
-        },
-        "NAT3EIP": {
-            "Condition": "3AZCondition",
-            "Type": "AWS::EC2::EIP",
-            "Properties": {
-                "Domain": "vpc",
-                "InstanceId": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "NATInstance3"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                }
-            }
-        },
-        "NAT4EIP": {
-            "Condition": "4AZCondition",
-            "Type": "AWS::EC2::EIP",
-            "Properties": {
-                "Domain": "vpc",
-                "InstanceId": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "NATInstance4"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                }
-            }
-        },
-        "NATGateway1": {
-            "Condition": "NATGatewayCondition",
-            "DependsOn": "VPCGatewayAttachment",
-            "Type": "AWS::EC2::NatGateway",
-            "Properties": {
-                "AllocationId": {
-                    "Fn::GetAtt": [
-                        "NAT1EIP",
-                        "AllocationId"
-                    ]
-                },
-                "SubnetId": {
-                    "Ref": "PublicSubnet1"
-                }
-            }
-        },
-        "NATGateway2": {
-            "Condition": "NATGatewayCondition",
-            "DependsOn": "VPCGatewayAttachment",
-            "Type": "AWS::EC2::NatGateway",
-            "Properties": {
-                "AllocationId": {
-                    "Fn::GetAtt": [
-                        "NAT2EIP",
-                        "AllocationId"
-                    ]
-                },
-                "SubnetId": {
-                    "Ref": "PublicSubnet2"
-                }
-            }
-        },
-        "NATGateway3": {
-            "Condition": "NATGateway&3AZCondition",
-            "DependsOn": "VPCGatewayAttachment",
-            "Type": "AWS::EC2::NatGateway",
-            "Properties": {
-                "AllocationId": {
-                    "Fn::GetAtt": [
-                        "NAT3EIP",
-                        "AllocationId"
-                    ]
-                },
-                "SubnetId": {
-                    "Ref": "PublicSubnet3"
-                }
-            }
-        },
-        "NATGateway4": {
-            "Condition": "NATGateway&4AZCondition",
-            "DependsOn": "VPCGatewayAttachment",
-            "Type": "AWS::EC2::NatGateway",
-            "Properties": {
-                "AllocationId": {
-                    "Fn::GetAtt": [
-                        "NAT4EIP",
-                        "AllocationId"
-                    ]
-                },
-                "SubnetId": {
-                    "Ref": "PublicSubnet4"
-                }
-            }
-        },
-        "NATInstance1": {
-            "Condition": "NATInstanceCondition",
-            "DependsOn": "VPCGatewayAttachment",
-            "Type": "AWS::EC2::Instance",
-            "Properties": {
-                "ImageId": {
-                    "Fn::FindInMap": [
-                        "AWSAMIRegionMap",
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        "AWSNAT"
-                    ]
-                },
-                "InstanceType": {
-                    "Ref": "NATInstanceType"
-                },
-                "Tags": [
-                    {
-                        "Key": "Name",
-                        "Value": "NAT1"
-                    }
-                ],
-                "NetworkInterfaces": [
-                    {
-                        "GroupSet": [
-                            {
-                                "Ref": "NATInstanceSecurityGroup"
-                            }
-                        ],
-                        "AssociatePublicIpAddress": "true",
-                        "DeviceIndex": "0",
-                        "DeleteOnTermination": "true",
-                        "SubnetId": {
-                            "Ref": "PublicSubnet1"
-                        }
-                    }
-                ],
-                "KeyName": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "KeyPairName"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "SourceDestCheck": "false"
-            }
-        },
-        "NATInstance2": {
-            "Condition": "NATInstanceCondition",
-            "DependsOn": "VPCGatewayAttachment",
-            "Type": "AWS::EC2::Instance",
-            "Properties": {
-                "ImageId": {
-                    "Fn::FindInMap": [
-                        "AWSAMIRegionMap",
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        "AWSNAT"
-                    ]
-                },
-                "InstanceType": {
-                    "Ref": "NATInstanceType"
-                },
-                "Tags": [
-                    {
-                        "Key": "Name",
-                        "Value": "NAT2"
-                    }
-                ],
-                "NetworkInterfaces": [
-                    {
-                        "GroupSet": [
-                            {
-                                "Ref": "NATInstanceSecurityGroup"
-                            }
-                        ],
-                        "AssociatePublicIpAddress": "true",
-                        "DeviceIndex": "0",
-                        "DeleteOnTermination": "true",
-                        "SubnetId": {
-                            "Ref": "PublicSubnet2"
-                        }
-                    }
-                ],
-                "KeyName": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "KeyPairName"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "SourceDestCheck": "false"
-            }
-        },
-        "NATInstance3": {
-            "Condition": "NATInstance&3AZCondition",
-            "DependsOn": "VPCGatewayAttachment",
-            "Type": "AWS::EC2::Instance",
-            "Properties": {
-                "ImageId": {
-                    "Fn::FindInMap": [
-                        "AWSAMIRegionMap",
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        "AWSNAT"
-                    ]
-                },
-                "InstanceType": {
-                    "Ref": "NATInstanceType"
-                },
-                "Tags": [
-                    {
-                        "Key": "Name",
-                        "Value": "NAT3"
-                    }
-                ],
-                "NetworkInterfaces": [
-                    {
-                        "GroupSet": [
-                            {
-                                "Ref": "NATInstanceSecurityGroup"
-                            }
-                        ],
-                        "AssociatePublicIpAddress": "true",
-                        "DeviceIndex": "0",
-                        "DeleteOnTermination": "true",
-                        "SubnetId": {
-                            "Ref": "PublicSubnet3"
-                        }
-                    }
-                ],
-                "KeyName": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "KeyPairName"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "SourceDestCheck": "false"
-            }
-        },
-        "NATInstance4": {
-            "Condition": "NATInstance&4AZCondition",
-            "DependsOn": "VPCGatewayAttachment",
-            "Type": "AWS::EC2::Instance",
-            "Properties": {
-                "ImageId": {
-                    "Fn::FindInMap": [
-                        "AWSAMIRegionMap",
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        "AWSNAT"
-                    ]
-                },
-                "InstanceType": {
-                    "Ref": "NATInstanceType"
-                },
-                "Tags": [
-                    {
-                        "Key": "Name",
-                        "Value": "NAT4"
-                    }
-                ],
-                "NetworkInterfaces": [
-                    {
-                        "GroupSet": [
-                            {
-                                "Ref": "NATInstanceSecurityGroup"
-                            }
-                        ],
-                        "AssociatePublicIpAddress": "true",
-                        "DeviceIndex": "0",
-                        "DeleteOnTermination": "true",
-                        "SubnetId": {
-                            "Ref": "PublicSubnet4"
-                        }
-                    }
-                ],
-                "KeyName": {
-                    "Fn::If": [
-                        "NATInstanceCondition",
-                        {
-                            "Ref": "KeyPairName"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "SourceDestCheck": "false"
-            }
-        },
-        "NATInstanceSecurityGroup": {
-            "Condition": "NATInstanceCondition",
-            "Type": "AWS::EC2::SecurityGroup",
-            "Properties": {
-                "GroupDescription": "Enables outbound internet access for the VPC via the NAT instances",
-                "VpcId": {
-                    "Ref": "VPC"
-                },
-                "SecurityGroupIngress": [
-                    {
-                        "IpProtocol": "-1",
-                        "FromPort": "1",
-                        "ToPort": "65535",
-                        "CidrIp": {
-                            "Ref": "VPCCIDR"
-                        }
-                    }
-                ]
-            }
-        }
-    },
-    "Outputs": {
-        "PrivateSubnet1ACIDR": {
-            "Description": "Private subnet 1A CIDR in Availability Zone 1",
-            "Value": {
-                "Ref": "PrivateSubnet1ACIDR"
-            }
-        },
-        "PrivateSubnet1AID": {
-            "Description": "Private subnet 1A ID in Availability Zone 1",
-            "Value": {
-                "Ref": "PrivateSubnet1A"
-            }
-        },
-        "PrivateSubnet1BCIDR": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Description": "Private subnet 1B CIDR in Availability Zone 1",
-            "Value": {
-                "Ref": "PrivateSubnet1BCIDR"
-            }
-        },
-        "PrivateSubnet1BID": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Description": "Private subnet 1B ID in Availability Zone 1",
-            "Value": {
-                "Ref": "PrivateSubnet1B"
-            }
-        },
-        "PrivateSubnet2ACIDR": {
-            "Description": "Private subnet 2A CIDR in Availability Zone 2",
-            "Value": {
-                "Ref": "PrivateSubnet2ACIDR"
-            }
-        },
-        "PrivateSubnet2AID": {
-            "Description": "Private subnet 2A ID in Availability Zone 2",
-            "Value": {
-                "Ref": "PrivateSubnet2A"
-            }
-        },
-        "PrivateSubnet2BCIDR": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Description": "Private subnet 2B CIDR in Availability Zone 2",
-            "Value": {
-                "Ref": "PrivateSubnet2BCIDR"
-            }
-        },
-        "PrivateSubnet2BID": {
-            "Condition": "AdditionalPrivateSubnetsCondition",
-            "Description": "Private subnet 2B ID in Availability Zone 2",
-            "Value": {
-                "Ref": "PrivateSubnet2B"
-            }
-        },
-        "PrivateSubnet3ACIDR": {
-            "Condition": "3AZCondition",
-            "Description": "Private subnet 3A CIDR in Availability Zone 3",
-            "Value": {
-                "Ref": "PrivateSubnet3ACIDR"
-            }
-        },
-        "PrivateSubnet3AID": {
-            "Condition": "3AZCondition",
-            "Description": "Private subnet 3A ID in Availability Zone 3",
-            "Value": {
-                "Ref": "PrivateSubnet3A"
-            }
-        },
-        "PrivateSubnet3BCIDR": {
-            "Condition": "AdditionalPrivateSubnets&3AZCondition",
-            "Description": "Private subnet 3B CIDR in Availability Zone 3",
-            "Value": {
-                "Ref": "PrivateSubnet3BCIDR"
-            }
-        },
-        "PrivateSubnet3BID": {
-            "Condition": "AdditionalPrivateSubnets&3AZCondition",
-            "Description": "Private subnet 3B ID in Availability Zone 3",
-            "Value": {
-                "Ref": "PrivateSubnet3B"
-            }
-        },
-        "PrivateSubnet4ACIDR": {
-            "Condition": "4AZCondition",
-            "Description": "Private subnet 4A CIDR in Availability Zone 4",
-            "Value": {
-                "Ref": "PrivateSubnet4ACIDR"
-            }
-        },
-        "PrivateSubnet4AID": {
-            "Condition": "4AZCondition",
-            "Description": "Private subnet 4A ID in Availability Zone 4",
-            "Value": {
-                "Ref": "PrivateSubnet4A"
-            }
-        },
-        "PrivateSubnet4BCIDR": {
-            "Condition": "AdditionalPrivateSubnets&4AZCondition",
-            "Description": "Private subnet 4B CIDR in Availability Zone 4",
-            "Value": {
-                "Ref": "PrivateSubnet4BCIDR"
-            }
-        },
-        "PrivateSubnet4BID": {
-            "Condition": "AdditionalPrivateSubnets&4AZCondition",
-            "Description": "Private subnet 4B ID in Availability Zone 4",
-            "Value": {
-                "Ref": "PrivateSubnet4B"
-            }
-        },
-        "PublicSubnet1CIDR": {
-            "Description": "Public subnet 1 CIDR in Availability Zone 1",
-            "Value": {
-                "Ref": "PublicSubnet1CIDR"
-            }
-        },
-        "PublicSubnet1ID": {
-            "Description": "Public subnet 1 ID in Availability Zone 1",
-            "Value": {
-                "Ref": "PublicSubnet1"
-            }
-        },
-        "PublicSubnet2CIDR": {
-            "Description": "Public subnet 2 CIDR in Availability Zone 2",
-            "Value": {
-                "Ref": "PublicSubnet2CIDR"
-            }
-        },
-        "PublicSubnet2ID": {
-            "Description": "Public subnet 2 ID in Availability Zone 2",
-            "Value": {
-                "Ref": "PublicSubnet2"
-            }
-        },
-        "PublicSubnet3CIDR": {
-            "Condition": "3AZCondition",
-            "Description": "Public subnet 3 CIDR in Availability Zone 3",
-            "Value": {
-                "Ref": "PublicSubnet3CIDR"
-            }
-        },
-        "PublicSubnet3ID": {
-            "Condition": "3AZCondition",
-            "Description": "Public subnet 3 ID in Availability Zone 3",
-            "Value": {
-                "Ref": "PublicSubnet3"
-            }
-        },
-        "PublicSubnet4CIDR": {
-            "Condition": "4AZCondition",
-            "Description": "Public subnet 4 CIDR in Availability Zone 4",
-            "Value": {
-                "Ref": "PublicSubnet4CIDR"
-            }
-        },
-        "PublicSubnet4ID": {
-            "Condition": "4AZCondition",
-            "Description": "Public subnet 4 ID in Availability Zone 4",
-            "Value": {
-                "Ref": "PublicSubnet4"
-            }
-        },
-        "VPCCIDR": {
-            "Value": {
-                "Ref": "VPCCIDR"
-            },
-            "Description": "VPC CIDR"
-        },
-        "VPCID": {
-            "Value": {
-                "Ref": "VPC"
-            },
-            "Description": "VPC ID"
-        }
+      }
     }
+  },
+  "Parameters": {
+    "AvailabilityZones": {
+      "Description": "List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved.",
+      "Type": "List<AWS::EC2::AvailabilityZone::Name>"
+    },
+    "CreateAdditionalPrivateSubnets": {
+      "AllowedValues": [
+        "true",
+        "false"
+      ],
+      "Default": "false",
+      "Description": "Set to true to create a network ACL protected subnet in each Availability Zone. If false, the CIDR parameters for those subnets will be ignored.",
+      "Type": "String"
+    },
+    "KeyPairName": {
+      "Description": "Public/private key pairs allow you to securely connect to your NAT instance after it launches. This is used only if the region does not support NAT gateways.",
+      "Type": "AWS::EC2::KeyPair::KeyName"
+    },
+    "NATInstanceType": {
+      "AllowedValues": [
+        "t2.nano",
+        "t2.micro",
+        "t2.small",
+        "t2.medium",
+        "t2.large",
+        "m3.medium",
+        "m3.large",
+        "m4.large"
+      ],
+      "Default": "t2.micro",
+      "Description": "Amazon EC2 instance type for the NAT instances. This is used only if the region does not support NAT gateways.",
+      "Type": "String"
+    },
+    "NumberOfAZs": {
+      "AllowedValues": [
+        "2",
+        "3",
+        "4"
+      ],
+      "Default": "2",
+      "Description": "Number of Availability Zones to use in the VPC. This must match your selections in the list of Availability Zones parameter.",
+      "Type": "String"
+    },
+    "PrivateSubnetANamePrefix": {
+      "Default": "private",
+      "Description": "Friendly name for the private subnet set A. Ex: a value of 'private' will result in subnets named like this: <VPCName>-private-us-east-1a",
+      "Type": "String"
+    },
+    "PrivateSubnetBNamePrefix": {
+      "Default": "protected",
+      "Description": "Friendly name for the private subnet set B. Ex: a value of 'protected' will result in subnets named like this: <VPCName>-protected-us-east-1a",
+      "Type": "String"
+    },
+    "PrivateSubnet1ACIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.0.0/19",
+      "Description": "CIDR block for private subnet 1A located in Availability Zone 1",
+      "Type": "String"
+    },
+    "PrivateSubnet1BCIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.48.0/21",
+      "Description": "CIDR block for private subnet 1B with dedicated network ACL located in Availability Zone 1",
+      "Type": "String"
+    },
+    "PrivateSubnet2ACIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.64.0/19",
+      "Description": "CIDR block for private subnet 2A located in Availability Zone 2",
+      "Type": "String"
+    },
+    "PrivateSubnet2BCIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.112.0/21",
+      "Description": "CIDR block for private subnet 2B with dedicated network ACL located in Availability Zone 2",
+      "Type": "String"
+    },
+    "PrivateSubnet3ACIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.128.0/19",
+      "Description": "CIDR block for private subnet 3A located in Availability Zone 3",
+      "Type": "String"
+    },
+    "PrivateSubnet3BCIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.176.0/21",
+      "Description": "CIDR block for private subnet 3B with dedicated network ACL located in Availability Zone 3",
+      "Type": "String"
+    },
+    "PrivateSubnet4ACIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.192.0/19",
+      "Description": "CIDR block for private subnet 4A located in Availability Zone 4",
+      "Type": "String"
+    },
+    "PrivateSubnet4BCIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.240.0/21",
+      "Description": "CIDR block for private subnet 4B with dedicated network ACL located in Availability Zone 4",
+      "Type": "String"
+    },
+    "PublicSubnetNamePrefix": {
+      "Default": "public",
+      "Description": "Friendly name for the public subnets. Ex: a value of 'public' will result in subnets named like this: <VPCName>-public-us-east-1a",
+      "Type": "String"
+    },
+    "PublicSubnet1CIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.32.0/20",
+      "Description": "CIDR block for the public DMZ subnet 1 located in Availability Zone 1",
+      "Type": "String"
+    },
+    "PublicSubnet2CIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.96.0/20",
+      "Description": "CIDR block for the public DMZ subnet 2 located in Availability Zone 2",
+      "Type": "String"
+    },
+    "PublicSubnet3CIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.160.0/20",
+      "Description": "CIDR block for the public DMZ subnet 3 located in Availability Zone 3",
+      "Type": "String"
+    },
+    "PublicSubnet4CIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.224.0/20",
+      "Description": "CIDR block for the public DMZ subnet 4 located in Availability Zone 4",
+      "Type": "String"
+    },
+    "VPCCIDR": {
+      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+      "Default": "10.0.0.0/16",
+      "Description": "CIDR block for the VPC",
+      "Type": "String"
+    },
+    "VPCName": {
+      "Default": "DevVPC",
+      "Description": "Friendly name for the VPC",
+      "Type": "String"
+    }
+  },
+  "Mappings": {
+    "AWSAMIRegionMap": {
+      "AMI": {
+        "AWSNAT": "amzn-ami-vpc-nat-hvm-2016.03.3.x86_64-ebs"
+      },
+      "ap-northeast-1": {
+        "AWSNAT": "ami-2443b745"
+      },
+      "ap-northeast-2": {
+        "AWSNAT": "ami-d14388bf"
+      },
+      "ap-south-1": {
+        "AWSNAT": "ami-e2b9d38d"
+      },
+      "ap-southeast-1": {
+        "AWSNAT": "ami-a79b49c4"
+      },
+      "ap-southeast-2": {
+        "AWSNAT": "ami-53371f30"
+      },
+      "eu-central-1": {
+        "AWSNAT": "ami-5825cd37"
+      },
+      "eu-west-1": {
+        "AWSNAT": "ami-a8dd45db"
+      },
+      "sa-east-1": {
+        "AWSNAT": "ami-9336bcff"
+      },
+      "us-east-1": {
+        "AWSNAT": "ami-4868ab25"
+      },
+      "us-west-1": {
+        "AWSNAT": "ami-004b0f60"
+      },
+      "us-west-2": {
+        "AWSNAT": "ami-a275b1c2"
+      }
+    }
+  },
+  "Conditions": {
+    "3AZCondition": {
+      "Fn::Or": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "NumberOfAZs"
+            },
+            "3"
+          ]
+        },
+        {
+          "Condition": "4AZCondition"
+        }
+      ]
+    },
+    "4AZCondition": {
+      "Fn::Equals": [
+        {
+          "Ref": "NumberOfAZs"
+        },
+        "4"
+      ]
+    },
+    "AdditionalPrivateSubnetsCondition": {
+      "Fn::Equals": [
+        {
+          "Ref": "CreateAdditionalPrivateSubnets"
+        },
+        "true"
+      ]
+    },
+    "AdditionalPrivateSubnets&3AZCondition": {
+      "Fn::And": [
+        {
+          "Condition": "AdditionalPrivateSubnetsCondition"
+        },
+        {
+          "Condition": "3AZCondition"
+        }
+      ]
+    },
+    "AdditionalPrivateSubnets&4AZCondition": {
+      "Fn::And": [
+        {
+          "Condition": "AdditionalPrivateSubnetsCondition"
+        },
+        {
+          "Condition": "4AZCondition"
+        }
+      ]
+    },
+    "NATInstanceCondition": {
+      "Fn::Or": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "sa-east-1"
+          ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "us-gov-west-1"
+          ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "cn-north-1"
+          ]
+        }
+      ]
+    },
+    "NATGatewayCondition": {
+      "Fn::Not": [
+        {
+          "Condition": "NATInstanceCondition"
+        }
+      ]
+    },
+    "NATInstance&3AZCondition": {
+      "Fn::And": [
+        {
+          "Condition": "NATInstanceCondition"
+        },
+        {
+          "Condition": "3AZCondition"
+        }
+      ]
+    },
+    "NATInstance&4AZCondition": {
+      "Fn::And": [
+        {
+          "Condition": "NATInstanceCondition"
+        },
+        {
+          "Condition": "4AZCondition"
+        }
+      ]
+    },
+    "NATGateway&3AZCondition": {
+      "Fn::And": [
+        {
+          "Condition": "NATGatewayCondition"
+        },
+        {
+          "Condition": "3AZCondition"
+        }
+      ]
+    },
+    "NATGateway&4AZCondition": {
+      "Fn::And": [
+        {
+          "Condition": "NATGatewayCondition"
+        },
+        {
+          "Condition": "4AZCondition"
+        }
+      ]
+    },
+    "VPCEndpointCondition": {
+      "Fn::Not": [
+        {
+          "Fn::Or": [
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "us-gov-west-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "cn-north-1"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "Resources": {
+    "DHCPOptions": {
+      "Type": "AWS::EC2::DHCPOptions",
+      "Properties": {
+        "DomainNameServers": [
+          "AmazonProvidedDNS"
+        ]
+      }
+    },
+    "VPC": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": {
+          "Ref": "VPCCIDR"
+        },
+        "EnableDnsSupport": "true",
+        "EnableDnsHostnames": "true",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Ref": "VPCName"
+            }
+          }
+        ]
+      }
+    },
+    "VPCDHCPOptionsAssociation": {
+      "Type": "AWS::EC2::VPCDHCPOptionsAssociation",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "DhcpOptionsId": {
+          "Ref": "DHCPOptions"
+        }
+      }
+    },
+    "InternetGateway": {
+      "Type": "AWS::EC2::InternetGateway",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Network",
+            "Value": "Public"
+          }
+        ]
+      }
+    },
+    "VPCGatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "InternetGatewayId": {
+          "Ref": "InternetGateway"
+        }
+      }
+    },
+    "PrivateSubnet1A": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "PrivateSubnet1ACIDR"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "0",
+            {
+              "Ref": "AvailabilityZones"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetANamePrefix"}, {"Fn::Select": ["0", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 1A"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet1B": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "PrivateSubnet1BCIDR"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "0",
+            {
+              "Ref": "AvailabilityZones"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetBNamePrefix"}, {"Fn::Select": ["0", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 1B"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet2A": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "PrivateSubnet2ACIDR"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "1",
+            {
+              "Ref": "AvailabilityZones"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetANamePrefix"}, {"Fn::Select": ["1", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 2A"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet2B": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "PrivateSubnet2BCIDR"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "1",
+            {
+              "Ref": "AvailabilityZones"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetBNamePrefix"}, {"Fn::Select": ["1", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 2B"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet3A": {
+      "Condition": "3AZCondition",
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "PrivateSubnet3ACIDR"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "2",
+            {
+              "Ref": "AvailabilityZones"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetANamePrefix"}, {"Fn::Select": ["2", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 3A"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet3B": {
+      "Condition": "AdditionalPrivateSubnets&3AZCondition",
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "PrivateSubnet3BCIDR"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "2",
+            {
+              "Ref": "AvailabilityZones"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetBNamePrefix"}, {"Fn::Select": ["2", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 3B"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet4A": {
+      "Condition": "4AZCondition",
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "PrivateSubnet4ACIDR"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "3",
+            {
+              "Ref": "AvailabilityZones"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetANamePrefix"}, {"Fn::Select": ["3", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 4A"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet4B": {
+      "Condition": "AdditionalPrivateSubnets&4AZCondition",
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "PrivateSubnet4BCIDR"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "3",
+            {
+              "Ref": "AvailabilityZones"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetBNamePrefix"}, {"Fn::Select": ["3", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 4B"
+          }
+        ]
+      }
+    },
+    "PublicSubnet1": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "PublicSubnet1CIDR"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "0",
+            {
+              "Ref": "AvailabilityZones"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PublicSubnetNamePrefix"}, {"Fn::Select": ["0", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Public"
+          },
+          {
+            "Key": "Role",
+            "Value": "Public subnet 1"
+          }
+        ]
+      }
+    },
+    "PublicSubnet2": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "PublicSubnet2CIDR"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "1",
+            {
+              "Ref": "AvailabilityZones"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PublicSubnetNamePrefix"}, {"Fn::Select": ["1", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Public"
+          },
+          {
+            "Key": "Role",
+            "Value": "Public subnet 2"
+          }
+        ]
+      }
+    },
+    "PublicSubnet3": {
+      "Condition": "3AZCondition",
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "PublicSubnet3CIDR"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "2",
+            {
+              "Ref": "AvailabilityZones"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PublicSubnetNamePrefix"}, {"Fn::Select": ["2", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Public"
+          },
+          {
+            "Key": "Role",
+            "Value": "Public subnet 3"
+          }
+        ]
+      }
+    },
+    "PublicSubnet4": {
+      "Condition": "4AZCondition",
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": {
+          "Ref": "PublicSubnet4CIDR"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "3",
+            {
+              "Ref": "AvailabilityZones"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PublicSubnetNamePrefix"}, {"Fn::Select": ["3", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Public"
+          },
+          {
+            "Key": "Role",
+            "Value": "Public subnet 4"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet1ARouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetANamePrefix"}, {"Fn::Select": ["0", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 1A"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet1ARoute": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateSubnet1ARouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "InstanceId": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "NATInstance1"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "NatGatewayId": {
+          "Fn::If": [
+            "NATGatewayCondition",
+            {
+              "Ref": "NATGateway1"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "PrivateSubnet1ARouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet1A"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateSubnet1ARouteTable"
+        }
+      }
+    },
+    "PrivateSubnet2ARouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetANamePrefix"}, {"Fn::Select": ["1", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 2A"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet2ARoute": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateSubnet2ARouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "InstanceId": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "NATInstance2"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "NatGatewayId": {
+          "Fn::If": [
+            "NATGatewayCondition",
+            {
+              "Ref": "NATGateway2"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "PrivateSubnet2ARouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet2A"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateSubnet2ARouteTable"
+        }
+      }
+    },
+    "PrivateSubnet3ARouteTable": {
+      "Condition": "3AZCondition",
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetANamePrefix"}, {"Fn::Select": ["2", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 3A"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet3ARoute": {
+      "Condition": "3AZCondition",
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateSubnet3ARouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "InstanceId": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "NATInstance3"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "NatGatewayId": {
+          "Fn::If": [
+            "NATGatewayCondition",
+            {
+              "Ref": "NATGateway3"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "PrivateSubnet3ARouteTableAssociation": {
+      "Condition": "3AZCondition",
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet3A"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateSubnet3ARouteTable"
+        }
+      }
+    },
+    "PrivateSubnet4ARouteTable": {
+      "Condition": "4AZCondition",
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetANamePrefix"}, {"Fn::Select": ["3", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 4A"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet4ARoute": {
+      "Condition": "4AZCondition",
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateSubnet4ARouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "InstanceId": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "NATInstance4"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "NatGatewayId": {
+          "Fn::If": [
+            "NATGatewayCondition",
+            {
+              "Ref": "NATGateway4"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "PrivateSubnet4ARouteTableAssociation": {
+      "Condition": "4AZCondition",
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet4A"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateSubnet4ARouteTable"
+        }
+      }
+    },
+    "PrivateSubnet1BRouteTable": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetBNamePrefix"}, {"Fn::Select": ["0", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 1B"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet1BRoute": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateSubnet1BRouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "InstanceId": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "NATInstance1"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "NatGatewayId": {
+          "Fn::If": [
+            "NATGatewayCondition",
+            {
+              "Ref": "NATGateway1"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "PrivateSubnet1BRouteTableAssociation": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet1B"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateSubnet1BRouteTable"
+        }
+      }
+    },
+    "PrivateSubnet1BNetworkAcl": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::NetworkAcl",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetBNamePrefix"}, {"Fn::Select": ["0", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "NACL Protected"
+          },
+          {
+            "Key": "Role",
+            "Value": "NACL Protected subnet 1"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet1BNetworkAclEntryInbound": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "CidrBlock": "0.0.0.0/0",
+        "Egress": "false",
+        "NetworkAclId": {
+          "Ref": "PrivateSubnet1BNetworkAcl"
+        },
+        "Protocol": "-1",
+        "RuleAction": "allow",
+        "RuleNumber": "100"
+      }
+    },
+    "PrivateSubnet1BNetworkAclEntryOutbound": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "CidrBlock": "0.0.0.0/0",
+        "Egress": "true",
+        "NetworkAclId": {
+          "Ref": "PrivateSubnet1BNetworkAcl"
+        },
+        "Protocol": "-1",
+        "RuleAction": "allow",
+        "RuleNumber": "100"
+      }
+    },
+    "PrivateSubnet1BNetworkAclAssociation": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::SubnetNetworkAclAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet1B"
+        },
+        "NetworkAclId": {
+          "Ref": "PrivateSubnet1BNetworkAcl"
+        }
+      }
+    },
+    "PrivateSubnet2BRouteTable": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetBNamePrefix"}, {"Fn::Select": ["1", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 2B"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet2BRoute": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateSubnet2BRouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "InstanceId": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "NATInstance2"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "NatGatewayId": {
+          "Fn::If": [
+            "NATGatewayCondition",
+            {
+              "Ref": "NATGateway2"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "PrivateSubnet2BRouteTableAssociation": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet2B"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateSubnet2BRouteTable"
+        }
+      }
+    },
+    "PrivateSubnet2BNetworkAcl": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::NetworkAcl",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetBNamePrefix"}, {"Fn::Select": ["1", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "NACL Protected"
+          },
+          {
+            "Key": "Role",
+            "Value": "NACL Protected subnet 2"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet2BNetworkAclEntryInbound": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "CidrBlock": "0.0.0.0/0",
+        "Egress": "false",
+        "NetworkAclId": {
+          "Ref": "PrivateSubnet2BNetworkAcl"
+        },
+        "Protocol": "-1",
+        "RuleAction": "allow",
+        "RuleNumber": "100"
+      }
+    },
+    "PrivateSubnet2BNetworkAclEntryOutbound": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "CidrBlock": "0.0.0.0/0",
+        "Egress": "true",
+        "NetworkAclId": {
+          "Ref": "PrivateSubnet2BNetworkAcl"
+        },
+        "Protocol": "-1",
+        "RuleAction": "allow",
+        "RuleNumber": "100"
+      }
+    },
+    "PrivateSubnet2BNetworkAclAssociation": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Type": "AWS::EC2::SubnetNetworkAclAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet2B"
+        },
+        "NetworkAclId": {
+          "Ref": "PrivateSubnet2BNetworkAcl"
+        }
+      }
+    },
+    "PrivateSubnet3BRouteTable": {
+      "Condition": "AdditionalPrivateSubnets&3AZCondition",
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetBNamePrefix"}, {"Fn::Select": ["2", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 3B"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet3BRoute": {
+      "Condition": "AdditionalPrivateSubnets&3AZCondition",
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateSubnet3BRouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "InstanceId": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "NATInstance3"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "NatGatewayId": {
+          "Fn::If": [
+            "NATGatewayCondition",
+            {
+              "Ref": "NATGateway3"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "PrivateSubnet3BRouteTableAssociation": {
+      "Condition": "AdditionalPrivateSubnets&3AZCondition",
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet3B"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateSubnet3BRouteTable"
+        }
+      }
+    },
+    "PrivateSubnet3BNetworkAcl": {
+      "Condition": "AdditionalPrivateSubnets&3AZCondition",
+      "Type": "AWS::EC2::NetworkAcl",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetBNamePrefix"}, {"Fn::Select": ["2", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "NACL Protected"
+          },
+          {
+            "Key": "Role",
+            "Value": "NACL Protected subnet 3"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet3BNetworkAclEntryInbound": {
+      "Condition": "AdditionalPrivateSubnets&3AZCondition",
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "CidrBlock": "0.0.0.0/0",
+        "Egress": "false",
+        "NetworkAclId": {
+          "Ref": "PrivateSubnet3BNetworkAcl"
+        },
+        "Protocol": "-1",
+        "RuleAction": "allow",
+        "RuleNumber": "100"
+      }
+    },
+    "PrivateSubnet3BNetworkAclEntryOutbound": {
+      "Condition": "AdditionalPrivateSubnets&3AZCondition",
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "CidrBlock": "0.0.0.0/0",
+        "Egress": "true",
+        "NetworkAclId": {
+          "Ref": "PrivateSubnet3BNetworkAcl"
+        },
+        "Protocol": "-1",
+        "RuleAction": "allow",
+        "RuleNumber": "100"
+      }
+    },
+    "PrivateSubnet3BNetworkAclAssociation": {
+      "Condition": "AdditionalPrivateSubnets&3AZCondition",
+      "Type": "AWS::EC2::SubnetNetworkAclAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet3B"
+        },
+        "NetworkAclId": {
+          "Ref": "PrivateSubnet3BNetworkAcl"
+        }
+      }
+    },
+    "PrivateSubnet4BRouteTable": {
+      "Condition": "AdditionalPrivateSubnets&4AZCondition",
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetBNamePrefix"}, {"Fn::Select": ["3", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          },
+          {
+            "Key": "Role",
+            "Value": "Private subnet 4B"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet4BRoute": {
+      "Condition": "AdditionalPrivateSubnets&4AZCondition",
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateSubnet4BRouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "InstanceId": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "NATInstance4"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "NatGatewayId": {
+          "Fn::If": [
+            "NATGatewayCondition",
+            {
+              "Ref": "NATGateway4"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "PrivateSubnet4BRouteTableAssociation": {
+      "Condition": "AdditionalPrivateSubnets&4AZCondition",
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet4B"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateSubnet4BRouteTable"
+        }
+      }
+    },
+    "PrivateSubnet4BNetworkAcl": {
+      "Condition": "AdditionalPrivateSubnets&4AZCondition",
+      "Type": "AWS::EC2::NetworkAcl",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PrivateSubnetBNamePrefix"}, {"Fn::Select": ["3", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "NACL Protected"
+          },
+          {
+            "Key": "Role",
+            "Value": "NACL Protected subnet 4"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet4BNetworkAclEntryInbound": {
+      "Condition": "AdditionalPrivateSubnets&4AZCondition",
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "CidrBlock": "0.0.0.0/0",
+        "Egress": "false",
+        "NetworkAclId": {
+          "Ref": "PrivateSubnet4BNetworkAcl"
+        },
+        "Protocol": "-1",
+        "RuleAction": "allow",
+        "RuleNumber": "100"
+      }
+    },
+    "PrivateSubnet4BNetworkAclEntryOutbound": {
+      "Condition": "AdditionalPrivateSubnets&4AZCondition",
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "CidrBlock": "0.0.0.0/0",
+        "Egress": "true",
+        "NetworkAclId": {
+          "Ref": "PrivateSubnet4BNetworkAcl"
+        },
+        "Protocol": "-1",
+        "RuleAction": "allow",
+        "RuleNumber": "100"
+      }
+    },
+    "PrivateSubnet4BNetworkAclAssociation": {
+      "Condition": "AdditionalPrivateSubnets&4AZCondition",
+      "Type": "AWS::EC2::SubnetNetworkAclAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet4B"
+        },
+        "NetworkAclId": {
+          "Ref": "PrivateSubnet4BNetworkAcl"
+        }
+      }
+    },
+    "PublicSubnetRouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [{"Ref": "VPCName"}, {"Ref": "PublicSubnetNamePrefix"}]
+              ]
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Public"
+          }
+        ]
+      }
+    },
+    "PublicSubnetRoute": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PublicSubnetRouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "InternetGateway"
+        }
+      }
+    },
+    "PublicSubnet1RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PublicSubnet1"
+        },
+        "RouteTableId": {
+          "Ref": "PublicSubnetRouteTable"
+        }
+      }
+    },
+    "PublicSubnet2RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PublicSubnet2"
+        },
+        "RouteTableId": {
+          "Ref": "PublicSubnetRouteTable"
+        }
+      }
+    },
+    "PublicSubnet3RouteTableAssociation": {
+      "Condition": "3AZCondition",
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PublicSubnet3"
+        },
+        "RouteTableId": {
+          "Ref": "PublicSubnetRouteTable"
+        }
+      }
+    },
+    "PublicSubnet4RouteTableAssociation": {
+      "Condition": "4AZCondition",
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PublicSubnet4"
+        },
+        "RouteTableId": {
+          "Ref": "PublicSubnetRouteTable"
+        }
+      }
+    },
+    "NAT1EIP": {
+      "Type": "AWS::EC2::EIP",
+      "Properties": {
+        "Domain": "vpc",
+        "InstanceId": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "NATInstance1"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "NAT2EIP": {
+      "Type": "AWS::EC2::EIP",
+      "Properties": {
+        "Domain": "vpc",
+        "InstanceId": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "NATInstance2"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "NAT3EIP": {
+      "Condition": "3AZCondition",
+      "Type": "AWS::EC2::EIP",
+      "Properties": {
+        "Domain": "vpc",
+        "InstanceId": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "NATInstance3"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "NAT4EIP": {
+      "Condition": "4AZCondition",
+      "Type": "AWS::EC2::EIP",
+      "Properties": {
+        "Domain": "vpc",
+        "InstanceId": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "NATInstance4"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "NATGateway1": {
+      "Condition": "NATGatewayCondition",
+      "DependsOn": "VPCGatewayAttachment",
+      "Type": "AWS::EC2::NatGateway",
+      "Properties": {
+        "AllocationId": {
+          "Fn::GetAtt": [
+            "NAT1EIP",
+            "AllocationId"
+          ]
+        },
+        "SubnetId": {
+          "Ref": "PublicSubnet1"
+        }
+      }
+    },
+    "NATGateway2": {
+      "Condition": "NATGatewayCondition",
+      "DependsOn": "VPCGatewayAttachment",
+      "Type": "AWS::EC2::NatGateway",
+      "Properties": {
+        "AllocationId": {
+          "Fn::GetAtt": [
+            "NAT2EIP",
+            "AllocationId"
+          ]
+        },
+        "SubnetId": {
+          "Ref": "PublicSubnet2"
+        }
+      }
+    },
+    "NATGateway3": {
+      "Condition": "NATGateway&3AZCondition",
+      "DependsOn": "VPCGatewayAttachment",
+      "Type": "AWS::EC2::NatGateway",
+      "Properties": {
+        "AllocationId": {
+          "Fn::GetAtt": [
+            "NAT3EIP",
+            "AllocationId"
+          ]
+        },
+        "SubnetId": {
+          "Ref": "PublicSubnet3"
+        }
+      }
+    },
+    "NATGateway4": {
+      "Condition": "NATGateway&4AZCondition",
+      "DependsOn": "VPCGatewayAttachment",
+      "Type": "AWS::EC2::NatGateway",
+      "Properties": {
+        "AllocationId": {
+          "Fn::GetAtt": [
+            "NAT4EIP",
+            "AllocationId"
+          ]
+        },
+        "SubnetId": {
+          "Ref": "PublicSubnet4"
+        }
+      }
+    },
+    "NATInstance1": {
+      "Condition": "NATInstanceCondition",
+      "DependsOn": "VPCGatewayAttachment",
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "ImageId": {
+          "Fn::FindInMap": [
+            "AWSAMIRegionMap",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AWSNAT"
+          ]
+        },
+        "InstanceType": {
+          "Ref": "NATInstanceType"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                ["NAT", {"Fn::Select": ["0", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          }
+        ],
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "NATInstanceSecurityGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "SubnetId": {
+              "Ref": "PublicSubnet1"
+            }
+          }
+        ],
+        "KeyName": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "KeyPairName"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "SourceDestCheck": "false"
+      }
+    },
+    "NATInstance2": {
+      "Condition": "NATInstanceCondition",
+      "DependsOn": "VPCGatewayAttachment",
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "ImageId": {
+          "Fn::FindInMap": [
+            "AWSAMIRegionMap",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AWSNAT"
+          ]
+        },
+        "InstanceType": {
+          "Ref": "NATInstanceType"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                ["NAT", {"Fn::Select": ["1", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          }
+        ],
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "NATInstanceSecurityGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "SubnetId": {
+              "Ref": "PublicSubnet2"
+            }
+          }
+        ],
+        "KeyName": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "KeyPairName"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "SourceDestCheck": "false"
+      }
+    },
+    "NATInstance3": {
+      "Condition": "NATInstance&3AZCondition",
+      "DependsOn": "VPCGatewayAttachment",
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "ImageId": {
+          "Fn::FindInMap": [
+            "AWSAMIRegionMap",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AWSNAT"
+          ]
+        },
+        "InstanceType": {
+          "Ref": "NATInstanceType"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                ["NAT", {"Fn::Select": ["2", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          }
+        ],
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "NATInstanceSecurityGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "SubnetId": {
+              "Ref": "PublicSubnet3"
+            }
+          }
+        ],
+        "KeyName": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "KeyPairName"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "SourceDestCheck": "false"
+      }
+    },
+    "NATInstance4": {
+      "Condition": "NATInstance&4AZCondition",
+      "DependsOn": "VPCGatewayAttachment",
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "ImageId": {
+          "Fn::FindInMap": [
+            "AWSAMIRegionMap",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AWSNAT"
+          ]
+        },
+        "InstanceType": {
+          "Ref": "NATInstanceType"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                ["NAT", {"Fn::Select": ["3", {"Ref": "AvailabilityZones"}]}]
+              ]
+            }
+          }
+        ],
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "NATInstanceSecurityGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "SubnetId": {
+              "Ref": "PublicSubnet4"
+            }
+          }
+        ],
+        "KeyName": {
+          "Fn::If": [
+            "NATInstanceCondition",
+            {
+              "Ref": "KeyPairName"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "SourceDestCheck": "false"
+      }
+    },
+    "NATInstanceSecurityGroup": {
+      "Condition": "NATInstanceCondition",
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Enables outbound internet access for the VPC via the NAT instances",
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "-1",
+            "FromPort": "1",
+            "ToPort": "65535",
+            "CidrIp": {
+              "Ref": "VPCCIDR"
+            }
+          }
+        ]
+      }
+    },
+    "S3Endpoint": {
+      "Condition": "VPCEndpointCondition",
+      "Type": "AWS::EC2::VPCEndpoint",
+      "Properties": {
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "*",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Principal": "*"
+            }
+          ]
+        },
+        "RouteTableIds": [
+          {"Ref": "PrivateSubnet1ARouteTable"},
+          {"Ref": "PrivateSubnet2ARouteTable"},
+          {
+            "Fn::If": ["3AZCondition", {"Ref": "PrivateSubnet3ARouteTable"}, {"Ref": "AWS::NoValue"}]
+          },
+          {
+            "Fn::If": ["4AZCondition", {"Ref": "PrivateSubnet4ARouteTable"}, {"Ref": "AWS::NoValue"}]
+          },
+          {
+            "Fn::If": ["AdditionalPrivateSubnetsCondition", {"Ref": "PrivateSubnet1BRouteTable"}, {"Ref": "AWS::NoValue"}]
+          },
+          {
+            "Fn::If": ["AdditionalPrivateSubnetsCondition", {"Ref": "PrivateSubnet2BRouteTable"}, {"Ref": "AWS::NoValue"}]
+          },
+          {
+            "Fn::If": ["AdditionalPrivateSubnets&3AZCondition", {"Ref": "PrivateSubnet3BRouteTable"}, {"Ref": "AWS::NoValue"}]
+          },
+          {
+            "Fn::If": ["AdditionalPrivateSubnets&4AZCondition", {"Ref": "PrivateSubnet4BRouteTable"}, {"Ref": "AWS::NoValue"}]
+          }
+        ],
+        "ServiceName": { "Fn::Join": ["", ["com.amazonaws.", {"Ref":"AWS::Region"},".s3"]]},
+        "VpcId": {"Ref": "VPC"}
+      }
+    }
+  },
+  "Outputs": {
+    "PrivateSubnet1ACIDR": {
+      "Description": "Private subnet 1A CIDR in Availability Zone 1",
+      "Value": {
+        "Ref": "PrivateSubnet1ACIDR"
+      }
+    },
+    "PrivateSubnet1AID": {
+      "Description": "Private subnet 1A ID in Availability Zone 1",
+      "Value": {
+        "Ref": "PrivateSubnet1A"
+      }
+    },
+    "PrivateSubnet1BCIDR": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Description": "Private subnet 1B CIDR in Availability Zone 1",
+      "Value": {
+        "Ref": "PrivateSubnet1BCIDR"
+      }
+    },
+    "PrivateSubnet1BID": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Description": "Private subnet 1B ID in Availability Zone 1",
+      "Value": {
+        "Ref": "PrivateSubnet1B"
+      }
+    },
+    "PrivateSubnet2ACIDR": {
+      "Description": "Private subnet 2A CIDR in Availability Zone 2",
+      "Value": {
+        "Ref": "PrivateSubnet2ACIDR"
+      }
+    },
+    "PrivateSubnet2AID": {
+      "Description": "Private subnet 2A ID in Availability Zone 2",
+      "Value": {
+        "Ref": "PrivateSubnet2A"
+      }
+    },
+    "PrivateSubnet2BCIDR": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Description": "Private subnet 2B CIDR in Availability Zone 2",
+      "Value": {
+        "Ref": "PrivateSubnet2BCIDR"
+      }
+    },
+    "PrivateSubnet2BID": {
+      "Condition": "AdditionalPrivateSubnetsCondition",
+      "Description": "Private subnet 2B ID in Availability Zone 2",
+      "Value": {
+        "Ref": "PrivateSubnet2B"
+      }
+    },
+    "PrivateSubnet3ACIDR": {
+      "Condition": "3AZCondition",
+      "Description": "Private subnet 3A CIDR in Availability Zone 3",
+      "Value": {
+        "Ref": "PrivateSubnet3ACIDR"
+      }
+    },
+    "PrivateSubnet3AID": {
+      "Condition": "3AZCondition",
+      "Description": "Private subnet 3A ID in Availability Zone 3",
+      "Value": {
+        "Ref": "PrivateSubnet3A"
+      }
+    },
+    "PrivateSubnet3BCIDR": {
+      "Condition": "AdditionalPrivateSubnets&3AZCondition",
+      "Description": "Private subnet 3B CIDR in Availability Zone 3",
+      "Value": {
+        "Ref": "PrivateSubnet3BCIDR"
+      }
+    },
+    "PrivateSubnet3BID": {
+      "Condition": "AdditionalPrivateSubnets&3AZCondition",
+      "Description": "Private subnet 3B ID in Availability Zone 3",
+      "Value": {
+        "Ref": "PrivateSubnet3B"
+      }
+    },
+    "PrivateSubnet4ACIDR": {
+      "Condition": "4AZCondition",
+      "Description": "Private subnet 4A CIDR in Availability Zone 4",
+      "Value": {
+        "Ref": "PrivateSubnet4ACIDR"
+      }
+    },
+    "PrivateSubnet4AID": {
+      "Condition": "4AZCondition",
+      "Description": "Private subnet 4A ID in Availability Zone 4",
+      "Value": {
+        "Ref": "PrivateSubnet4A"
+      }
+    },
+    "PrivateSubnet4BCIDR": {
+      "Condition": "AdditionalPrivateSubnets&4AZCondition",
+      "Description": "Private subnet 4B CIDR in Availability Zone 4",
+      "Value": {
+        "Ref": "PrivateSubnet4BCIDR"
+      }
+    },
+    "PrivateSubnet4BID": {
+      "Condition": "AdditionalPrivateSubnets&4AZCondition",
+      "Description": "Private subnet 4B ID in Availability Zone 4",
+      "Value": {
+        "Ref": "PrivateSubnet4B"
+      }
+    },
+    "PublicSubnet1CIDR": {
+      "Description": "Public subnet 1 CIDR in Availability Zone 1",
+      "Value": {
+        "Ref": "PublicSubnet1CIDR"
+      }
+    },
+    "PublicSubnet1ID": {
+      "Description": "Public subnet 1 ID in Availability Zone 1",
+      "Value": {
+        "Ref": "PublicSubnet1"
+      }
+    },
+    "PublicSubnet2CIDR": {
+      "Description": "Public subnet 2 CIDR in Availability Zone 2",
+      "Value": {
+        "Ref": "PublicSubnet2CIDR"
+      }
+    },
+    "PublicSubnet2ID": {
+      "Description": "Public subnet 2 ID in Availability Zone 2",
+      "Value": {
+        "Ref": "PublicSubnet2"
+      }
+    },
+    "PublicSubnet3CIDR": {
+      "Condition": "3AZCondition",
+      "Description": "Public subnet 3 CIDR in Availability Zone 3",
+      "Value": {
+        "Ref": "PublicSubnet3CIDR"
+      }
+    },
+    "PublicSubnet3ID": {
+      "Condition": "3AZCondition",
+      "Description": "Public subnet 3 ID in Availability Zone 3",
+      "Value": {
+        "Ref": "PublicSubnet3"
+      }
+    },
+    "PublicSubnet4CIDR": {
+      "Condition": "4AZCondition",
+      "Description": "Public subnet 4 CIDR in Availability Zone 4",
+      "Value": {
+        "Ref": "PublicSubnet4CIDR"
+      }
+    },
+    "PublicSubnet4ID": {
+      "Condition": "4AZCondition",
+      "Description": "Public subnet 4 ID in Availability Zone 4",
+      "Value": {
+        "Ref": "PublicSubnet4"
+      }
+    },
+    "VPCCIDR": {
+      "Value": {
+        "Ref": "VPCCIDR"
+      },
+      "Description": "VPC CIDR"
+    },
+    "VPCID": {
+      "Value": {
+        "Ref": "VPC"
+      },
+      "Description": "VPC ID"
+    }
+  }
 }


### PR DESCRIPTION
…S3 VPC Endpoint to private subnets.

As a user of this QuickStart, it was very hard to use the resources it created as nothing had a 'Name' tag.  I have modified the template to tag resources appropriately.  For example, a subnet could end up with a Name tag of 'DevVPC-private-us-east-1b'.  These tags are derived automatically via parameters and environmental information.  I have continued the use of the conditionals throughout.

Additionally, I have added a S3 endpoint and associated it with the proper route tables (also continuing the use of the conditionals).  Why not send traffic local to S3 instead of relying on NAT / NAT Gateway?