### PR TITLE
Add NAT GW EIPs to outputs

### DIFF
--- a/templates/aws-vpc.template
+++ b/templates/aws-vpc.template
@@ -2208,6 +2208,32 @@
         }
     },
     "Outputs": {
+        "NAT1EIP": {
+            "Description": "NAT Gateway 1 IP address",
+            "Value": {
+                "Ref": "NAT1EIP"
+            }
+        },
+        "NAT2EIP": {
+            "Description": "NAT Gateway 2 IP address",
+            "Value": {
+                "Ref": "NAT2EIP"
+            }
+        },
+        "NAT3EIP": {
+            "Condition": "3AZCondition",
+            "Description": "NAT Gateway 3 IP address",
+            "Value": {
+                "Ref": "NAT3EIP"
+            }
+        },
+        "NAT4EIP": {
+            "Condition": "4AZCondition",
+            "Description": "NAT Gateway 4 IP address",
+            "Value": {
+                "Ref": "NAT4EIP"
+            }
+        },
         "PrivateSubnet1ACIDR": {
             "Description": "Private subnet 1A CIDR in Availability Zone 1",
             "Value": {


### PR DESCRIPTION
We need NAT GW EIPs to add permissions when creating ElasticSearch domain since ElasticSearch does not support VPC yet.
There might be other use cases as well.