### PR TITLE
Added Name Tag to Internet Gateway

### DIFF
--- a/templates/aws-vpc.template
+++ b/templates/aws-vpc.template
@@ -540,6 +540,12 @@
             "Properties": {
                 "Tags": [
                     {
+                        "Key": "Name",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    {
                         "Key": "Network",
                         "Value": "Public"
                     }


### PR DESCRIPTION
Seems like that's the only resource with name tag missing.
It was useful to have a tag to quickly distinguish between several IGWs in my AWS account.