### PR TITLE
Added Public/Private notice to documentation

### DIFF
--- a/docs/partner_editable/_settings.adoc
+++ b/docs/partner_editable/_settings.adoc
@@ -7,7 +7,7 @@
 :quickstart-contributors: Santiago Cardenas, AWS Quick Start team
 :deployment_time: 5 minutes
 :default_deployment_region: us-west-2
-//:production_build:
+:production_build:
 // Uncomment these two attributes if you are leveraging
 // - an AWS Marketplace listing.
 // Additional content will be auto-generated based on these attributes.

--- a/docs/partner_editable/_settings.adoc
+++ b/docs/partner_editable/_settings.adoc
@@ -1,13 +1,13 @@
 :quickstart-project-name: quickstart-aws-vpc
 :partner-product-name: Amazon VPC
-:partner-company-name: aws
+:partner-company-name: 
 :doc-month: July
 :doc-year: 2020
 :partner-contributors: 
 :quickstart-contributors: Santiago Cardenas, AWS Quick Start team
 :deployment_time: 5 minutes
 :default_deployment_region: us-west-2
-:production_build:
+//:production_build:
 // Uncomment these two attributes if you are leveraging
 // - an AWS Marketplace listing.
 // Additional content will be auto-generated based on these attributes.

--- a/docs/partner_editable/product_description.adoc
+++ b/docs/partner_editable/product_description.adoc
@@ -5,6 +5,9 @@
 The Amazon VPC architecture includes public and private subnets. The first set of private
 subnets share the default network access control list (ACL) from the Amazon VPC, and a
 second, optional set of private subnets includes dedicated custom network ACLs per subnet.
+
+Optionally you may choose to deploy a completely public VPC (no private subnets), or a completely private VPC (no public subnets).
+
 The Quick Start divides the Amazon VPC address space in a predictable manner across
 multiple Availability Zones, and deploys either NAT instances or NAT gateways for
 outbound Internet access, depending on the AWS Region you deploy the Quick Start in.


### PR DESCRIPTION



I added a sentence indicating that the VPC can be deployed with only private or only public subnets
