### PR TITLE
formatting,tags,nat-conditions,documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+taskcat_outputs/*
+.taskcat_overrides.yml
+.taskcat/*
+.DS_Store

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -12,8 +12,8 @@ project:
     - ap-southeast-2
     - ap-northeast-1
     - ca-central-1
-    - cn-north-1
-    - cn-northwest-1
+    # - cn-north-1
+    # - cn-northwest-1
     - eu-central-1
     - eu-west-1
     - eu-west-2

--- a/docs/partner_editable/additional_info.adoc
+++ b/docs/partner_editable/additional_info.adoc
@@ -52,9 +52,9 @@ traffic within and outside the Amazon VPC. The public subnets share a single rou
 table, because they all use the same Internet gateway as the sole route to communicate
 with the Internet.
 
-* Highly available NAT gateways, where supported, instead of NAT instances. NAT
-gateways offer major advantages in terms of deployment, availability, and maintenance.
-For more information see the http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-comparison.html[comparison] provided in the Amazon VPC documentation.
+* Highly available NAT gateways deployed, that offer major advantages in terms of deployment,
+availability, and maintenance over NAT instances. For more information see the http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-comparison.html[comparison]
+provided in the Amazon VPC documentation.
 
 * Spare capacity for additional subnets, to support your environment as it grows or
 changes over time.
@@ -79,13 +79,13 @@ following default CIDR block sizes to maximize capacity:
 
 [cols="60,40a", options="header",grid=none, frame=topbot, stripes=even]
 |===
-| VPC 
+| VPC
 ^| 10.0.0.0/16
 
 |Private subnets A
 ^|10.0.0.0/17
 |
-| 
+|
 [cols="2,1", grid=rows, frame=topbot]
 !===
 ! Availability Zone 1
@@ -100,7 +100,7 @@ following default CIDR block sizes to maximize capacity:
 |Public subnets
 ^|10.0.128.0/18
 |
-| 
+|
 [cols="2,1", grid=rows, frame=topbot]
 !===
 ! Availability Zone 1
@@ -118,7 +118,7 @@ dedicated custom network
 ACL
 ^|10.0.192.0/19
 |
-| 
+|
 [cols="2,1", grid=rows, frame=topbot]
 !===
 ! Availability Zone 1
@@ -134,7 +134,7 @@ ACL
 |Spare subnet capacity
 ^|10.0.224.0/19
 |
-| 
+|
 [cols="2,1", grid=rows, frame=topbot]
 !===
 ! Availability Zone 1
@@ -154,16 +154,16 @@ CIDR blocks to maximize capacity for this scenario are as follows:
 
 [cols="60,40a", options="header",grid=none, frame=topbot, stripes=even]
 |===
-| VPC 
+| VPC
 ^| 10.0.0.0/16
 
-|Availability Zone 1 
+|Availability Zone 1
 ^|10.0.0.0/18
 |
-| 
+|
 [cols="2,1", grid=rows, frame=topbot]
 !===
-! Private subnet A 
+! Private subnet A
 ^! 10.0.0.0/19
 ! Public subnet
 ^! 10.0.32.0/20
@@ -173,13 +173,13 @@ CIDR blocks to maximize capacity for this scenario are as follows:
 ^! 10.0.56.0/21
 !===
 
-|Availability Zone 2 
+|Availability Zone 2
 ^|10.0.64.0/18
 |
-| 
+|
 [cols="2,1", grid=rows, frame=topbot]
 !===
-! Private subnet A 
+! Private subnet A
 ^! 10.0.64.0/19
 ! Public subnet
 ^! 10.0.96.0/20
@@ -189,13 +189,13 @@ CIDR blocks to maximize capacity for this scenario are as follows:
 ^! 10.0.120.0/21
 !===
 
-|Availability Zone 3 
+|Availability Zone 3
 ^|10.0.128.0/18
 |
-| 
+|
 [cols="2,1", grid=rows, frame=topbot]
 !===
-! Private subnet A 
+! Private subnet A
 ^! 10.0.128.0/19
 ! Public subnet
 ^! 10.0.160.0/20
@@ -208,10 +208,10 @@ CIDR blocks to maximize capacity for this scenario are as follows:
 |Availability Zone 4
 ^|10.0.192.0/18
 |
-| 
+|
 [cols="2,1", grid=rows, frame=topbot]
 !===
-! Private subnet A 
+! Private subnet A
 ^! 10.0.192.0/19
 ! Public subnet
 ^! 10.0.224.0/20
@@ -241,8 +241,8 @@ to the Internet gateway. This type of subnet allows the use of Elastic IPs and p
 (if the security group and network ACLs permit) a public subnet is reachable from the
 Internet. A public subnet is useful as a DMZ infrastructure for web servers and for Internetfacing Elastic Load Balancing (ELB) load balancers.
 
-Private subnets can indirectly route to the Internet via a NAT instance or NAT gateway.
-These NAT devices reside in a public subnet in order to route directly to the Internet.
+Private subnets can indirectly route to the Internet via a NAT gateway.
+NAT Gateways reside in a public subnet in order to route directly to the Internet.
 Instances in a private subnet are not externally reachable from outside the Amazon VPC,
 regardless of whether they have a public or Elastic IP address attached. A private subnet is
 useful for application servers and databases.
@@ -274,27 +274,6 @@ you should use security groups to secure the environment internally, and you can
 down the custom network ACLs during or after deployment as required by your
 application.
 
-If the Quick Start deploys NAT instances instead of NAT gateways in the AWS Region you
-selected, it adds a single security group as a virtual firewall. This security group is required
-for NAT instances and any other instances in the private subnets to access the Internet. The
-security group is configured as follows:
-
-==== Inbound:
-|===
-|Source|Protocol|Ports
-
-|VPC CIDR|All|All
-|===
-
-==== Outbound:
-|===
-|Destination|Protocol|Ports
-
-|0.0.0.0/0 |All|All
-|===
-
-For additional details, see https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Security.html[Security in Your VPC] in the Amazon VPC documentation.
-
 == Other useful information
 //Provide any other information of interest to users, especially focusing on areas where AWS or cloud usage differs from on-premises usage.
 
@@ -320,4 +299,4 @@ For additional details, see https://docs.aws.amazon.com/AmazonVPC/latest/UserGui
 
 === GitHub Repository
 You can visit our https://fwd.aws/rdXz7[GitHub repository] to download the templates and scripts for this Quick
-Start, to post your comments, and to share your customizations with others. 
+Start, to post your comments, and to share your customizations with others.

--- a/docs/partner_editable/architecture.adoc
+++ b/docs/partner_editable/architecture.adoc
@@ -16,20 +16,19 @@ resources.
 
 The template creates a Multi-AZ, multi-subnet VPC infrastructure with managed NAT
 gateways in the public subnet for each Availability Zone. You can also create additional
-private subnets with dedicated custom network access control lists (ACLs). If you deploy
-the Quick Start in a region that doesn’t support NAT gateways, NAT instances are deployed
-instead. Default subnet sizes are based on a typical deployment but can be reconfigured, as
-discussed in the link:#_subnet_sizing[Subnet Sizing] section.
+private subnets with dedicated custom network access control lists (ACLs). Default subnet
+sizes are based on a typical deployment but can be reconfigured, as discussed in the
+link:#_subnet_sizing[Subnet Sizing] section.
 
 The Quick Start also includes VPC endpoints, which provide a secure, reliable connection to
-Amazon S3 without requiring an Internet gateway, a NAT device, or a virtual private
+Amazon S3 without requiring an Internet gateway, a NAT gateway, or a virtual private
 gateway. With these endpoints, you can access S3 resources from within the VPC created by
 the Quick Start. These endpoints are valid only for the AWS Region in which you launch the
 Quick Start.
 
 The Quick Start uses the default endpoint policy, which gives any user or service within the
 VPC full access to Amazon S3 resources. This policy supplements any IAM user policies or
-S3 bucket policies that you may have in place. 
+S3 bucket policies that you may have in place.
 
 The Quick Start also enables Domain Name System (DNS) resolution in the VPC. For more
 information about VPC endpoints, see the https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints-s3.html[AWS documentation].

--- a/docs/partner_editable/faq_troubleshooting.adoc
+++ b/docs/partner_editable/faq_troubleshooting.adoc
@@ -20,14 +20,4 @@ For additional information, see https://docs.aws.amazon.com/AWSCloudFormation/la
 
 The following table lists specific *CREATE_FAILED* error messages you might encounter.
 
-|===
-|Error message|Possible cause|What to do
-
-|*API: ec2: RunInstances Not authorized for images: ami-ID*|The template is referencing an AMI that has expired.|We refresh AMIs on a regular basis, but our schedule isn’t always synchronized with AWS AMI updates. If you get this error message, notify us, and we’ll update the template with the new AMI ID.
-
-If you’d like to fix the template yourself, you can https://fwd.aws/px53q[download it] and update the `Mappings` section with the latest AMI ID for your region.
-|*We currently do not have sufficient t2.small capacity in the AZ you requested*|The NAT instance requires a larger or different instance type|Switch to an instance type that supports higher capacity. If a higher-capacity instance type isn’t available, try a different Availability Zone or region. Or you can complete the https://console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase&limitType=service-code-[request form] in the AWS Support Center to increase the Amazon EC2 limit for the instance type or region. Limit increases are tied to the region they were requested for.
-|*Instance ID did not stabilize*|You have exceeded your IOPS for the region.|Request a limit increase by completing the https://console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase&limitType=service-code-[request form] in the AWS Support Center.
-|===
-
 If you encounter a template validation error during deployment, check for a mismatch in the values of the *Availability Zones* and *Number of Availability Zones* parameters. If you select more Availability Zones than you request, the AWS CloudFormation template won’t validate. Correct the parameters so that they’re in sync, and redeploy the Quick Start.

--- a/docs/partner_editable/product_description.adoc
+++ b/docs/partner_editable/product_description.adoc
@@ -1,5 +1,5 @@
 // Replace the content in <>
-// Briefly describe the software. Use consistent and clear branding. 
+// Briefly describe the software. Use consistent and clear branding.
 // Include the benefits of using the software on AWS, and provide details on usage scenarios.
 
 The Amazon VPC architecture includes public and private subnets. The first set of private
@@ -9,10 +9,9 @@ second, optional set of private subnets includes dedicated custom network ACLs p
 Optionally you may choose to deploy a completely public VPC (no private subnets), or a completely private VPC (no public subnets).
 
 The Quick Start divides the Amazon VPC address space in a predictable manner across
-multiple Availability Zones, and deploys either NAT instances or NAT gateways for
-outbound Internet access, depending on the AWS Region you deploy the Quick Start in.
+multiple Availability Zones, and deploys NAT gateways for outbound Internet access.
 
 You can use this Quick Start as a building block for your own deployments. You can scale it
 up or down by adding or removing subnets and Availability Zones according to your needs,
 and add other infrastructure components and software layers to complete your AWS
-environment. 
+environment.

--- a/templates/aws-vpc.template
+++ b/templates/aws-vpc.template
@@ -417,14 +417,6 @@
                 }
             ]
         },
-        "GovCloudCondition": {
-            "Fn::Equals": [
-                {
-                    "Ref": "AWS::Region"
-                },
-                "us-gov-west-1"
-            ]
-        },
         "NVirginiaRegionCondition": {
             "Fn::Equals": [
                 {

--- a/templates/aws-vpc.template.yaml
+++ b/templates/aws-vpc.template.yaml
@@ -63,7 +63,7 @@ Metadata:
           - VPCFlowLogsMaxAggregationInterval
           - VPCFlowLogsTrafficType
       - Label:
-          default: Deprecated: NAT Instance Configuration
+          default: Deprecated - NAT Instance Configuration
         Parameters:
           - KeyPairName
           - NATInstanceType

--- a/templates/aws-vpc.template.yaml
+++ b/templates/aws-vpc.template.yaml
@@ -1,14 +1,12 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >-
-  This template creates a Multi-AZ, multi-subnet VPC infrastructure with managed NAT
-  gateways in the public subnet for each Availability Zone. You can also create additional
-  private subnets with dedicated custom network access control lists (ACLs). If you
-  deploy the Quick Start in a region that doesn't support NAT gateways, NAT instances
-  are deployed instead. **WARNING** This template creates AWS resources. You will
-  be billed for the AWS resources used if you create a stack from this template. (qs-1qnnspaap)
+  This template creates a Multi-AZ, multi-subnet VPC infrastructure with managed NAT gateways in the public subnet for each Availability Zone. You can
+  also create additional private subnets with dedicated custom network access control lists (ACLs). If you deploy the Quick Start in a region that
+  doesn't support NAT gateways, NAT instances are deployed instead. **WARNING** This template creates AWS resources. You will be billed for the AWS
+  resources used if you create a stack from this template. (qs-1qnnspaap)
 Metadata:
   QuickStartDocumentation:
-    EntrypointName: "Launch a New VPC"
+    EntrypointName: 'Launch a New VPC'
     OptionalParameters:
       - PrivateSubnetATag1
       - PrivateSubnetATag2
@@ -57,7 +55,15 @@ Metadata:
           - PrivateSubnetBTag3
           - VPCTenancy
       - Label:
-          default: 'Deprecated: NAT Instance Configuration'
+          default: VPC Flow Logs Configuration
+        Parameters:
+          - CreateVPCFlowLogsToCloudWatch
+          - VPCFlowLogsLogFormat
+          - VPCFlowLogsLogGroupRetention
+          - VPCFlowLogsMaxAggregationInterval
+          - VPCFlowLogsTrafficType
+      - Label:
+          default: Deprecated: NAT Instance Configuration
         Parameters:
           - KeyPairName
           - NATInstanceType
@@ -68,10 +74,12 @@ Metadata:
         default: Create additional private subnets with dedicated network ACLs
       CreateNATGateways:
         default: Create NAT Gateways
-      CreatePublicSubnets:
-        default: Create public subnets
       CreatePrivateSubnets:
         default: Create private subnets
+      CreatePublicSubnets:
+        default: Create public subnets
+      CreateVPCFlowLogsToCloudWatch:
+        default: Create VPC Flow Logs (CloudWatch)
       KeyPairName:
         default: 'Deprecated: Key pair name'
       NATInstanceType:
@@ -122,12 +130,19 @@ Metadata:
         default: Tag for Public Subnets
       VPCCIDR:
         default: VPC CIDR
+      VPCFlowLogsLogFormat:
+        default: VPC Flow Logs - Log Format
+      VPCFlowLogsLogGroupRetention:
+        default: VPC Flow Logs - Log Group Retention
+      VPCFlowLogsMaxAggregationInterval:
+        default: VPC Flow Logs - Max Aggregation Interval
+      VPCFlowLogsTrafficType:
+        default: VPC Flow Logs - Traffic Type
       VPCTenancy:
         default: VPC Tenancy
 Parameters:
   AvailabilityZones:
-    Description: 'List of Availability Zones to use for the subnets in the VPC. Note:
-      The logical order is preserved.'
+    Description: 'List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved.'
     Type: List<AWS::EC2::AvailabilityZone::Name>
   CreateAdditionalPrivateSubnets:
     AllowedValues:
@@ -135,10 +150,8 @@ Parameters:
       - 'false'
     Default: 'false'
     Description: >-
-      Set to true to create a network ACL protected subnet in each Availability Zone.
-      If false, the CIDR parameters for those subnets will be ignored. If true, it
-      also requires that the 'Create private subnets' parameter is also true to have
-      any effect.
+      Set to true to create a network ACL protected subnet in each Availability Zone. If false, the CIDR parameters for those subnets will be ignored.
+      If true, it also requires that the 'Create private subnets' parameter is also true to have any effect.
     Type: String
   CreateNATGateways:
     AllowedValues:
@@ -152,20 +165,28 @@ Parameters:
       - 'true'
       - 'false'
     Default: 'true'
-    Description: Set to false to create only private subnets. If false, CreatePrivateSubnets must be True and the CIDR parameters for ALL public subnets will be ignored
+    Description:
+      Set to false to create only private subnets. If false, CreatePrivateSubnets must be True and the CIDR parameters for ALL public subnets will be
+      ignored
     Type: String
   CreatePrivateSubnets:
     AllowedValues:
       - 'true'
       - 'false'
     Default: 'true'
-    Description: Set to false to create only public subnets. If false, the CIDR parameters
-      for ALL private subnets will be ignored.
+    Description: Set to false to create only public subnets. If false, the CIDR parameters for ALL private subnets will be ignored.
+    Type: String
+  CreateVPCFlowLogsToCloudWatch:
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+    Description: Set to true to create VPC flow logs for the VPC and publish them to CloudWatch. If false, VPC flow logs will not be created.
     Type: String
   KeyPairName:
+    Default: deprecated
     Description: Deprecated. NAT gateways are now supported in all regions.
     Type: String
-    Default: deprecated
   NATInstanceType:
     Default: deprecated
     Description: Deprecated. NAT gateways are now supported in all regions.
@@ -176,8 +197,7 @@ Parameters:
       - '3'
       - '4'
     Default: '2'
-    Description: Number of Availability Zones to use in the VPC. This must match your
-      selections in the list of Availability Zones parameter.
+    Description: Number of Availability Zones to use in the VPC. This must match your selections in the list of Availability Zones parameter.
     Type: String
   PrivateSubnet1ACIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
@@ -189,8 +209,7 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
     Default: 10.0.192.0/21
-    Description: CIDR block for private subnet 1B with dedicated network ACL located
-      in Availability Zone 1
+    Description: CIDR block for private subnet 1B with dedicated network ACL located in Availability Zone 1
     Type: String
   PrivateSubnet2ACIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
@@ -202,8 +221,7 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
     Default: 10.0.200.0/21
-    Description: CIDR block for private subnet 2B with dedicated network ACL located
-      in Availability Zone 2
+    Description: CIDR block for private subnet 2B with dedicated network ACL located in Availability Zone 2
     Type: String
   PrivateSubnet3ACIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
@@ -215,8 +233,7 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
     Default: 10.0.208.0/21
-    Description: CIDR block for private subnet 3B with dedicated network ACL located
-      in Availability Zone 3
+    Description: CIDR block for private subnet 3B with dedicated network ACL located in Availability Zone 3
     Type: String
   PrivateSubnet4ACIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
@@ -228,48 +245,47 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
     Default: 10.0.216.0/21
-    Description: CIDR block for private subnet 4B with dedicated network ACL located
-      in Availability Zone 4
+    Description: CIDR block for private subnet 4B with dedicated network ACL located in Availability Zone 4
     Type: String
   PrivateSubnetATag1:
     AllowedPattern: ^([a-zA-Z0-9+\-._:/@]+=[a-zA-Z0-9+\-.,_:/@ *\\"'\[\]\{\}]*)?$
-    ConstraintDescription: tags must be in format "Key=Value" keys can only contain
-      [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
+    ConstraintDescription:
+      tags must be in format "Key=Value" keys can only contain [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
     Default: Network=Private
     Description: tag to add to private subnets A, in format Key=Value (Optional)
     Type: String
   PrivateSubnetATag2:
     AllowedPattern: ^([a-zA-Z0-9+\-._:/@]+=[a-zA-Z0-9+\-.,_:/@ *\\"'\[\]\{\}]*)?$
-    ConstraintDescription: tags must be in format "Key=Value" keys can only contain
-      [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
+    ConstraintDescription:
+      tags must be in format "Key=Value" keys can only contain [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
     Default: ''
     Description: tag to add to private subnets A, in format Key=Value (Optional)
     Type: String
   PrivateSubnetATag3:
     AllowedPattern: ^([a-zA-Z0-9+\-._:/@]+=[a-zA-Z0-9+\-.,_:/@ *\\"'\[\]\{\}]*)?$
-    ConstraintDescription: tags must be in format "Key=Value" keys can only contain
-      [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
+    ConstraintDescription:
+      tags must be in format "Key=Value" keys can only contain [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
     Default: ''
     Description: tag to add to private subnets A, in format Key=Value (Optional)
     Type: String
   PrivateSubnetBTag1:
     AllowedPattern: ^([a-zA-Z0-9+\-._:/@]+=[a-zA-Z0-9+\-.,_:/@ *\\"'\[\]\{\}]*)?$
-    ConstraintDescription: tags must be in format "Key=Value" keys can only contain
-      [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
+    ConstraintDescription:
+      tags must be in format "Key=Value" keys can only contain [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
     Default: Network=Private
     Description: tag to add to private subnets B, in format Key=Value (Optional)
     Type: String
   PrivateSubnetBTag2:
     AllowedPattern: ^([a-zA-Z0-9+\-._:/@]+=[a-zA-Z0-9+\-.,_:/@ *\\"'\[\]\{\}]*)?$
-    ConstraintDescription: tags must be in format "Key=Value" keys can only contain
-      [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
+    ConstraintDescription:
+      tags must be in format "Key=Value" keys can only contain [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
     Default: ''
     Description: tag to add to private subnets B, in format Key=Value (Optional)
     Type: String
   PrivateSubnetBTag3:
     AllowedPattern: ^([a-zA-Z0-9+\-._:/@]+=[a-zA-Z0-9+\-.,_:/@ *\\"'\[\]\{\}]*)?$
-    ConstraintDescription: tags must be in format "Key=Value" keys can only contain
-      [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
+    ConstraintDescription:
+      tags must be in format "Key=Value" keys can only contain [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
     Default: ''
     Description: tag to add to private subnets B, in format Key=Value (Optional)
     Type: String
@@ -277,48 +293,44 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
     Default: 10.0.128.0/20
-    Description: CIDR block for the public DMZ subnet 1 located in Availability Zone
-      1
+    Description: CIDR block for the public DMZ subnet 1 located in Availability Zone 1
     Type: String
   PublicSubnet2CIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
     Default: 10.0.144.0/20
-    Description: CIDR block for the public DMZ subnet 2 located in Availability Zone
-      2
+    Description: CIDR block for the public DMZ subnet 2 located in Availability Zone 2
     Type: String
   PublicSubnet3CIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
     Default: 10.0.160.0/20
-    Description: CIDR block for the public DMZ subnet 3 located in Availability Zone
-      3
+    Description: CIDR block for the public DMZ subnet 3 located in Availability Zone 3
     Type: String
   PublicSubnet4CIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
     Default: 10.0.176.0/20
-    Description: CIDR block for the public DMZ subnet 4 located in Availability Zone
-      4
+    Description: CIDR block for the public DMZ subnet 4 located in Availability Zone 4
     Type: String
   PublicSubnetTag1:
     AllowedPattern: ^([a-zA-Z0-9+\-._:/@]+=[a-zA-Z0-9+\-.,_:/@ *\\"'\[\]\{\}]*)?$
-    ConstraintDescription: tags must be in format "Key=Value" keys can only contain
-      [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
+    ConstraintDescription:
+      tags must be in format "Key=Value" keys can only contain [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
     Default: Network=Public
     Description: tag to add to public subnets, in format Key=Value (Optional)
     Type: String
   PublicSubnetTag2:
     AllowedPattern: ^([a-zA-Z0-9+\-._:/@]+=[a-zA-Z0-9+\-.,_:/@ *\\"'\[\]\{\}]*)?$
-    ConstraintDescription: tags must be in format "Key=Value" keys can only contain
-      [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
+    ConstraintDescription:
+      tags must be in format "Key=Value" keys can only contain [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
     Default: ''
     Description: tag to add to public subnets, in format Key=Value (Optional)
     Type: String
   PublicSubnetTag3:
     AllowedPattern: ^([a-zA-Z0-9+\-._:/@]+=[a-zA-Z0-9+\-.,_:/@ *\\"'\[\]\{\}]*)?$
-    ConstraintDescription: tags must be in format "Key=Value" keys can only contain
-      [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
+    ConstraintDescription:
+      tags must be in format "Key=Value" keys can only contain [a-zA-Z0-9+\-._:/@], values can contain [a-zA-Z0-9+\-._:/@ *\\"'\[\]\{\}]
     Default: ''
     Description: tag to add to public subnets, in format Key=Value (Optional)
     Type: String
@@ -327,6 +339,37 @@ Parameters:
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
     Default: 10.0.0.0/16
     Description: CIDR block for the VPC
+    Type: String
+  VPCFlowLogsLogFormat:
+    AllowedPattern: '^(\$\{[a-z-]+\})$|^((\$\{[a-z-]+\} )*\$\{[a-z-]+\})$'
+    Default:
+      '${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action}
+      ${log-status}'
+    Description:
+      The fields to include in the flow log record, in the order in which they should appear. Specify the fields using the ${field-id} format,
+      separated by spaces. Using the Default Format as the default value.
+    Type: String
+  VPCFlowLogsLogGroupRetention:
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+    Default: 14
+    Description: Number of days to retain the VPC Flow Logs in CloudWatch
+    Type: String
+  VPCFlowLogsMaxAggregationInterval:
+    AllowedValues:
+      - 60
+      - 600
+    Default: 600
+    Description:
+      The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. You can specify 60 seconds (1
+      minute) or 600 seconds (10 minutes).
+    Type: String
+  VPCFlowLogsTrafficType:
+    AllowedValues:
+      - ACCEPT
+      - ALL
+      - REJECT
+    Default: REJECT
+    Description: The type of traffic to log. You can log traffic that the resource accepts or rejects, or all traffic.
     Type: String
   VPCTenancy:
     AllowedValues:
@@ -351,20 +394,12 @@ Rules:
         AssertDescription: At least one of CreatePublicSubnets or CreatePrivateSubnets must be set to 'true'
 Conditions:
   3AZCondition: !Or
-    - !Equals
-      - !Ref 'NumberOfAZs'
-      - '3'
+    - !Equals [!Ref 'NumberOfAZs', '3']
     - !Condition '4AZCondition'
-  4AZCondition: !Equals
-    - !Ref 'NumberOfAZs'
-    - '4'
+  4AZCondition: !Equals [!Ref 'NumberOfAZs', '4']
   AdditionalPrivateSubnetsCondition: !And
-    - !Equals
-      - !Ref 'CreatePrivateSubnets'
-      - 'true'
-    - !Equals
-      - !Ref 'CreateAdditionalPrivateSubnets'
-      - 'true'
+    - !Equals [!Ref 'CreatePrivateSubnets', 'true']
+    - !Equals [!Ref 'CreateAdditionalPrivateSubnets', 'true']
   AdditionalPrivateSubnets&3AZCondition: !And
     - !Condition 'AdditionalPrivateSubnetsCondition'
     - !Condition '3AZCondition'
@@ -383,85 +418,58 @@ Conditions:
     - !Condition 'AdditionalPrivateSubnets&4AZCondition'
     - !Condition 'PublicSubnetsCondition'
     - !Condition 'NATGatewaysCondition'
-  GovCloudCondition: !Equals
-    - !Ref 'AWS::Region'
-    - us-gov-west-1
-  NATGatewaysCondition: !Equals
-    - !Ref 'CreateNATGateways'
-    - 'true'
-  NATGateways&3AZCondition: !And
+  NATGatewaysCondition: !Equals [!Ref 'CreateNATGateways', 'true']
+  NATGateways&PublicSubnets&PrivateSubnetsCondition: !And
     - !Condition 'NATGatewaysCondition'
+    - !Condition 'PublicSubnetsCondition'
+    - !Condition 'PrivateSubnetsCondition'
+  NATGateways&PublicSubnets&PrivateSubnets&3AZCondition: !And
+    - !Condition 'NATGatewaysCondition'
+    - !Condition 'PublicSubnetsCondition'
+    - !Condition 'PrivateSubnetsCondition'
     - !Condition '3AZCondition'
-  NATGateways&4AZCondition: !And
+  NATGateways&PublicSubnets&PrivateSubnets&4AZCondition: !And
     - !Condition 'NATGatewaysCondition'
+    - !Condition 'PublicSubnetsCondition'
+    - !Condition 'PrivateSubnetsCondition'
     - !Condition '4AZCondition'
-  NVirginiaRegionCondition: !Equals
-    - !Ref 'AWS::Region'
-    - us-east-1
-  PrivateSubnetsCondition: !Equals
-    - !Ref 'CreatePrivateSubnets'
-    - 'true'
+  NVirginiaRegionCondition: !Equals [!Ref 'AWS::Region', us-east-1]
+  PrivateSubnetsCondition: !Equals [!Ref 'CreatePrivateSubnets', 'true']
   PrivateSubnets&3AZCondition: !And
     - !Condition 'PrivateSubnetsCondition'
     - !Condition '3AZCondition'
   PrivateSubnets&4AZCondition: !And
     - !Condition 'PrivateSubnetsCondition'
     - !Condition '4AZCondition'
-  PublicSubnetsCondition: !Equals
-    - !Ref 'CreatePublicSubnets'
-    - 'true'
+  PublicSubnetsCondition: !Equals [!Ref 'CreatePublicSubnets', 'true']
   PublicSubnets&3AZCondition: !And
     - !Condition 'PublicSubnetsCondition'
     - !Condition '3AZCondition'
   PublicSubnets&4AZCondition: !And
     - !Condition 'PublicSubnetsCondition'
     - !Condition '4AZCondition'
-  PrivateSubnetATag1Condition: !Not
-    - !Equals
-      - !Ref 'PrivateSubnetATag1'
-      - ''
-  PrivateSubnetATag2Condition: !Not
-    - !Equals
-      - !Ref 'PrivateSubnetATag2'
-      - ''
-  PrivateSubnetATag3Condition: !Not
-    - !Equals
-      - !Ref 'PrivateSubnetATag3'
-      - ''
-  PrivateSubnetBTag1Condition: !Not
-    - !Equals
-      - !Ref 'PrivateSubnetBTag1'
-      - ''
-  PrivateSubnetBTag2Condition: !Not
-    - !Equals
-      - !Ref 'PrivateSubnetBTag2'
-      - ''
-  PrivateSubnetBTag3Condition: !Not
-    - !Equals
-      - !Ref 'PrivateSubnetBTag3'
-      - ''
-  PublicSubnetTag1Condition: !Not
-    - !Equals
-      - !Ref 'PublicSubnetTag1'
-      - ''
-  PublicSubnetTag2Condition: !Not
-    - !Equals
-      - !Ref 'PublicSubnetTag2'
-      - ''
-  PublicSubnetTag3Condition: !Not
-    - !Equals
-      - !Ref 'PublicSubnetTag3'
-      - ''
+  PrivateSubnetATag1Condition: !Not [!Equals [!Ref 'PrivateSubnetATag1', '']]
+  PrivateSubnetATag2Condition: !Not [!Equals [!Ref 'PrivateSubnetATag2', '']]
+  PrivateSubnetATag3Condition: !Not [!Equals [!Ref 'PrivateSubnetATag3', '']]
+  PrivateSubnetBTag1Condition: !Not [!Equals [!Ref 'PrivateSubnetBTag1', '']]
+  PrivateSubnetBTag2Condition: !Not [!Equals [!Ref 'PrivateSubnetBTag2', '']]
+  PrivateSubnetBTag3Condition: !Not [!Equals [!Ref 'PrivateSubnetBTag3', '']]
+  PublicSubnetTag1Condition: !Not [!Equals [!Ref 'PublicSubnetTag1', '']]
+  PublicSubnetTag2Condition: !Not [!Equals [!Ref 'PublicSubnetTag2', '']]
+  PublicSubnetTag3Condition: !Not [!Equals [!Ref 'PublicSubnetTag3', '']]
+  VPCFlowLogsToCloudWatchCondition: !Equals [!Ref 'CreateVPCFlowLogsToCloudWatch', 'true']
 Resources:
   DHCPOptions:
     Type: AWS::EC2::DHCPOptions
     Properties:
-      DomainName: !If
-        - NVirginiaRegionCondition
-        - ec2.internal
-        - !Sub '${AWS::Region}.compute.internal'
+      DomainName: !If [NVirginiaRegionCondition, ec2.internal, !Sub '${AWS::Region}.compute.internal']
       DomainNameServers:
         - AmazonProvidedDNS
+      Tags:
+        - Key: Name
+          Value: !Sub ${AWS::StackName} stack DHCPOptions
+        - Key: StackName
+          Value: !Ref AWS::StackName
   VPC:
     Type: AWS::EC2::VPC
     Properties:
@@ -496,50 +504,24 @@ Resources:
     Properties:
       VpcId: !Ref 'VPC'
       CidrBlock: !Ref 'PrivateSubnet1ACIDR'
-      AvailabilityZone: !Select
-        - '0'
-        - !Ref 'AvailabilityZones'
+      AvailabilityZone: !Select ['0', !Ref 'AvailabilityZones']
       Tags:
         - Key: Name
           Value: Private subnet 1A
         - !If
           - PrivateSubnetATag1Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag1'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag1'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetATag1']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetATag1']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetATag2Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag2'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag2'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetATag2']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetATag2']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetATag3Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag3'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag3'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetATag3']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetATag3']]
           - !Ref 'AWS::NoValue'
   PrivateSubnet1B:
     Condition: AdditionalPrivateSubnetsCondition
@@ -547,50 +529,24 @@ Resources:
     Properties:
       VpcId: !Ref 'VPC'
       CidrBlock: !Ref 'PrivateSubnet1BCIDR'
-      AvailabilityZone: !Select
-        - '0'
-        - !Ref 'AvailabilityZones'
+      AvailabilityZone: !Select ['0', !Ref 'AvailabilityZones']
       Tags:
         - Key: Name
           Value: Private subnet 1B
         - !If
           - PrivateSubnetBTag1Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag1'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag1'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetBTag1']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetBTag1']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetBTag2Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag2'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag2'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetBTag2']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetBTag2']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetBTag3Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag3'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag3'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetBTag3']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetBTag3']]
           - !Ref 'AWS::NoValue'
   PrivateSubnet2A:
     Condition: PrivateSubnetsCondition
@@ -598,50 +554,24 @@ Resources:
     Properties:
       VpcId: !Ref 'VPC'
       CidrBlock: !Ref 'PrivateSubnet2ACIDR'
-      AvailabilityZone: !Select
-        - '1'
-        - !Ref 'AvailabilityZones'
+      AvailabilityZone: !Select ['1', !Ref 'AvailabilityZones']
       Tags:
         - Key: Name
           Value: Private subnet 2A
         - !If
           - PrivateSubnetATag1Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag1'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag1'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetATag1']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetATag1']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetATag2Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag2'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag2'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetATag2']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetATag2']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetATag3Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag3'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag3'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetATag3']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetATag3']]
           - !Ref 'AWS::NoValue'
   PrivateSubnet2B:
     Condition: AdditionalPrivateSubnetsCondition
@@ -649,50 +579,24 @@ Resources:
     Properties:
       VpcId: !Ref 'VPC'
       CidrBlock: !Ref 'PrivateSubnet2BCIDR'
-      AvailabilityZone: !Select
-        - '1'
-        - !Ref 'AvailabilityZones'
+      AvailabilityZone: !Select ['1', !Ref 'AvailabilityZones']
       Tags:
         - Key: Name
           Value: Private subnet 2B
         - !If
           - PrivateSubnetBTag1Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag1'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag1'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetBTag1']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetBTag1']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetBTag2Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag2'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag2'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetBTag2']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetBTag2']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetBTag3Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag3'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag3'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetBTag3']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetBTag3']]
           - !Ref 'AWS::NoValue'
   PrivateSubnet3A:
     Condition: PrivateSubnets&3AZCondition
@@ -700,50 +604,24 @@ Resources:
     Properties:
       VpcId: !Ref 'VPC'
       CidrBlock: !Ref 'PrivateSubnet3ACIDR'
-      AvailabilityZone: !Select
-        - '2'
-        - !Ref 'AvailabilityZones'
+      AvailabilityZone: !Select ['2', !Ref 'AvailabilityZones']
       Tags:
         - Key: Name
           Value: Private subnet 3A
         - !If
           - PrivateSubnetATag1Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag1'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag1'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetATag1']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetATag1']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetATag2Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag2'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag2'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetATag2']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetATag2']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetATag3Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag3'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag3'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetATag3']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetATag3']]
           - !Ref 'AWS::NoValue'
   PrivateSubnet3B:
     Condition: AdditionalPrivateSubnets&3AZCondition
@@ -751,50 +629,24 @@ Resources:
     Properties:
       VpcId: !Ref 'VPC'
       CidrBlock: !Ref 'PrivateSubnet3BCIDR'
-      AvailabilityZone: !Select
-        - '2'
-        - !Ref 'AvailabilityZones'
+      AvailabilityZone: !Select ['2', !Ref 'AvailabilityZones']
       Tags:
         - Key: Name
           Value: Private subnet 3B
         - !If
           - PrivateSubnetBTag1Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag1'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag1'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetBTag1']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetBTag1']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetBTag2Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag2'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag2'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetBTag2']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetBTag2']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetBTag3Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag3'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag3'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetBTag3']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetBTag3']]
           - !Ref 'AWS::NoValue'
   PrivateSubnet4A:
     Condition: PrivateSubnets&4AZCondition
@@ -802,50 +654,24 @@ Resources:
     Properties:
       VpcId: !Ref 'VPC'
       CidrBlock: !Ref 'PrivateSubnet4ACIDR'
-      AvailabilityZone: !Select
-        - '3'
-        - !Ref 'AvailabilityZones'
+      AvailabilityZone: !Select ['3', !Ref 'AvailabilityZones']
       Tags:
         - Key: Name
           Value: Private subnet 4A
         - !If
           - PrivateSubnetATag1Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag1'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag1'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetATag1']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetATag1']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetATag2Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag2'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag2'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetATag2']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetATag2']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetATag3Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag3'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetATag3'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetATag3']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetATag3']]
           - !Ref 'AWS::NoValue'
   PrivateSubnet4B:
     Condition: AdditionalPrivateSubnets&4AZCondition
@@ -853,50 +679,24 @@ Resources:
     Properties:
       VpcId: !Ref 'VPC'
       CidrBlock: !Ref 'PrivateSubnet4BCIDR'
-      AvailabilityZone: !Select
-        - '3'
-        - !Ref 'AvailabilityZones'
+      AvailabilityZone: !Select ['3', !Ref 'AvailabilityZones']
       Tags:
         - Key: Name
           Value: Private subnet 4B
         - !If
           - PrivateSubnetBTag1Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag1'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag1'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetBTag1']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetBTag1']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetBTag2Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag2'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag2'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetBTag2']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetBTag2']]
           - !Ref 'AWS::NoValue'
         - !If
           - PrivateSubnetBTag3Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag3'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PrivateSubnetBTag3'
+          - Key: !Select ['0', !Split ['=', !Ref 'PrivateSubnetBTag3']]
+            Value: !Select ['1', !Split ['=', !Ref 'PrivateSubnetBTag3']]
           - !Ref 'AWS::NoValue'
   PublicSubnet1:
     Condition: PublicSubnetsCondition
@@ -904,50 +704,24 @@ Resources:
     Properties:
       VpcId: !Ref 'VPC'
       CidrBlock: !Ref 'PublicSubnet1CIDR'
-      AvailabilityZone: !Select
-        - '0'
-        - !Ref 'AvailabilityZones'
+      AvailabilityZone: !Select ['0', !Ref 'AvailabilityZones']
       Tags:
         - Key: Name
           Value: Public subnet 1
         - !If
           - PublicSubnetTag1Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag1'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag1'
+          - Key: !Select ['0', !Split ['=', !Ref 'PublicSubnetTag1']]
+            Value: !Select ['1', !Split ['=', !Ref 'PublicSubnetTag1']]
           - !Ref 'AWS::NoValue'
         - !If
           - PublicSubnetTag2Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag2'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag2'
+          - Key: !Select ['0', !Split ['=', !Ref 'PublicSubnetTag2']]
+            Value: !Select ['1', !Split ['=', !Ref 'PublicSubnetTag2']]
           - !Ref 'AWS::NoValue'
         - !If
           - PublicSubnetTag3Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag3'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag3'
+          - Key: !Select ['0', !Split ['=', !Ref 'PublicSubnetTag3']]
+            Value: !Select ['1', !Split ['=', !Ref 'PublicSubnetTag3']]
           - !Ref 'AWS::NoValue'
       MapPublicIpOnLaunch: true
   PublicSubnet2:
@@ -956,50 +730,24 @@ Resources:
     Properties:
       VpcId: !Ref 'VPC'
       CidrBlock: !Ref 'PublicSubnet2CIDR'
-      AvailabilityZone: !Select
-        - '1'
-        - !Ref 'AvailabilityZones'
+      AvailabilityZone: !Select ['1', !Ref 'AvailabilityZones']
       Tags:
         - Key: Name
           Value: Public subnet 2
         - !If
           - PublicSubnetTag1Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag1'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag1'
+          - Key: !Select ['0', !Split ['=', !Ref 'PublicSubnetTag1']]
+            Value: !Select ['1', !Split ['=', !Ref 'PublicSubnetTag1']]
           - !Ref 'AWS::NoValue'
         - !If
           - PublicSubnetTag2Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag2'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag2'
+          - Key: !Select ['0', !Split ['=', !Ref 'PublicSubnetTag2']]
+            Value: !Select ['1', !Split ['=', !Ref 'PublicSubnetTag2']]
           - !Ref 'AWS::NoValue'
         - !If
           - PublicSubnetTag3Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag3'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag3'
+          - Key: !Select ['0', !Split ['=', !Ref 'PublicSubnetTag3']]
+            Value: !Select ['1', !Split ['=', !Ref 'PublicSubnetTag3']]
           - !Ref 'AWS::NoValue'
       MapPublicIpOnLaunch: true
   PublicSubnet3:
@@ -1008,50 +756,24 @@ Resources:
     Properties:
       VpcId: !Ref 'VPC'
       CidrBlock: !Ref 'PublicSubnet3CIDR'
-      AvailabilityZone: !Select
-        - '2'
-        - !Ref 'AvailabilityZones'
+      AvailabilityZone: !Select ['2', !Ref 'AvailabilityZones']
       Tags:
         - Key: Name
           Value: Public subnet 3
         - !If
           - PublicSubnetTag1Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag1'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag1'
+          - Key: !Select ['0', !Split ['=', !Ref 'PublicSubnetTag1']]
+            Value: !Select ['1', !Split ['=', !Ref 'PublicSubnetTag1']]
           - !Ref 'AWS::NoValue'
         - !If
           - PublicSubnetTag2Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag2'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag2'
+          - Key: !Select ['0', !Split ['=', !Ref 'PublicSubnetTag2']]
+            Value: !Select ['1', !Split ['=', !Ref 'PublicSubnetTag2']]
           - !Ref 'AWS::NoValue'
         - !If
           - PublicSubnetTag3Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag3'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag3'
+          - Key: !Select ['0', !Split ['=', !Ref 'PublicSubnetTag3']]
+            Value: !Select ['1', !Split ['=', !Ref 'PublicSubnetTag3']]
           - !Ref 'AWS::NoValue'
       MapPublicIpOnLaunch: true
   PublicSubnet4:
@@ -1060,50 +782,24 @@ Resources:
     Properties:
       VpcId: !Ref 'VPC'
       CidrBlock: !Ref 'PublicSubnet4CIDR'
-      AvailabilityZone: !Select
-        - '3'
-        - !Ref 'AvailabilityZones'
+      AvailabilityZone: !Select ['3', !Ref 'AvailabilityZones']
       Tags:
         - Key: Name
           Value: Public subnet 4
         - !If
           - PublicSubnetTag1Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag1'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag1'
+          - Key: !Select ['0', !Split ['=', !Ref 'PublicSubnetTag1']]
+            Value: !Select ['1', !Split ['=', !Ref 'PublicSubnetTag1']]
           - !Ref 'AWS::NoValue'
         - !If
           - PublicSubnetTag2Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag2'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag2'
+          - Key: !Select ['0', !Split ['=', !Ref 'PublicSubnetTag2']]
+            Value: !Select ['1', !Split ['=', !Ref 'PublicSubnetTag2']]
           - !Ref 'AWS::NoValue'
         - !If
           - PublicSubnetTag3Condition
-          - Key: !Select
-              - '0'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag3'
-            Value: !Select
-              - '1'
-              - !Split
-                - '='
-                - !Ref 'PublicSubnetTag3'
+          - Key: !Select ['0', !Split ['=', !Ref 'PublicSubnetTag3']]
+            Value: !Select ['1', !Split ['=', !Ref 'PublicSubnetTag3']]
           - !Ref 'AWS::NoValue'
       MapPublicIpOnLaunch: true
   PrivateSubnet1ARouteTable:
@@ -1117,7 +813,7 @@ Resources:
         - Key: Network
           Value: Private
   PrivateSubnet1ARoute:
-    Condition: NATGatewaysCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnetsCondition
     Type: AWS::EC2::Route
     Properties:
       RouteTableId: !Ref 'PrivateSubnet1ARouteTable'
@@ -1140,7 +836,7 @@ Resources:
         - Key: Network
           Value: Private
   PrivateSubnet2ARoute:
-    Condition: NATGatewaysCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnetsCondition
     Type: AWS::EC2::Route
     Properties:
       RouteTableId: !Ref 'PrivateSubnet2ARouteTable'
@@ -1163,7 +859,7 @@ Resources:
         - Key: Network
           Value: Private
   PrivateSubnet3ARoute:
-    Condition: NATGateways&3AZCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnets&3AZCondition
     Type: AWS::EC2::Route
     Properties:
       RouteTableId: !Ref 'PrivateSubnet3ARouteTable'
@@ -1186,7 +882,7 @@ Resources:
         - Key: Network
           Value: Private
   PrivateSubnet4ARoute:
-    Condition: NATGateways&4AZCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnets&4AZCondition
     Type: AWS::EC2::Route
     Properties:
       RouteTableId: !Ref 'PrivateSubnet4ARouteTable'
@@ -1477,57 +1173,80 @@ Resources:
       SubnetId: !Ref 'PublicSubnet4'
       RouteTableId: !Ref 'PublicSubnetRouteTable'
   NAT1EIP:
-    Condition: NATGatewaysCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnetsCondition
     DependsOn: VPCGatewayAttachment
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
+      Tags:
+        - Key: Name
+          Value: NAT1EIP
   NAT2EIP:
-    Condition: NATGatewaysCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnetsCondition
     DependsOn: VPCGatewayAttachment
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
+      Tags:
+        - Key: Name
+          Value: NAT2EIP
   NAT3EIP:
-    Condition: NATGateways&3AZCondition
-    DependsOn: VPCGatewayAttachment
+    Condition: NATGateways&PublicSubnets&PrivateSubnets&3AZCondition
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
+      Tags:
+        - Key: Name
+          Value: NAT3EIP
   NAT4EIP:
-    Condition: NATGateways&4AZCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnets&4AZCondition
     DependsOn: VPCGatewayAttachment
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
+      Tags:
+        - Key: Name
+          Value: NAT4EIP
   NATGateway1:
-    Condition: NATGatewaysCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnetsCondition
     DependsOn: VPCGatewayAttachment
     Type: AWS::EC2::NatGateway
     Properties:
       AllocationId: !GetAtt 'NAT1EIP.AllocationId'
       SubnetId: !Ref 'PublicSubnet1'
+      Tags:
+        - Key: Name
+          Value: NATGateway1
   NATGateway2:
-    Condition: NATGatewaysCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnetsCondition
     DependsOn: VPCGatewayAttachment
     Type: AWS::EC2::NatGateway
     Properties:
       AllocationId: !GetAtt 'NAT2EIP.AllocationId'
       SubnetId: !Ref 'PublicSubnet2'
+      Tags:
+        - Key: Name
+          Value: NATGateway2
   NATGateway3:
-    Condition: NATGateways&3AZCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnets&3AZCondition
     DependsOn: VPCGatewayAttachment
     Type: AWS::EC2::NatGateway
     Properties:
       AllocationId: !GetAtt 'NAT3EIP.AllocationId'
       SubnetId: !Ref 'PublicSubnet3'
+      Tags:
+        - Key: Name
+          Value: NATGateway3
   NATGateway4:
-    Condition: NATGateways&4AZCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnets&4AZCondition
     DependsOn: VPCGatewayAttachment
     Type: AWS::EC2::NatGateway
     Properties:
       AllocationId: !GetAtt 'NAT4EIP.AllocationId'
       SubnetId: !Ref 'PublicSubnet4'
+      Tags:
+        - Key: Name
+          Value: NATGateway4
   S3VPCEndpoint:
     Condition: PrivateSubnetsCondition
     Type: AWS::EC2::VPCEndpoint
@@ -1542,53 +1261,82 @@ Resources:
       RouteTableIds:
         - !Ref 'PrivateSubnet1ARouteTable'
         - !Ref 'PrivateSubnet2ARouteTable'
-        - !If
-          - PrivateSubnets&3AZCondition
-          - !Ref 'PrivateSubnet3ARouteTable'
-          - !Ref 'AWS::NoValue'
-        - !If
-          - PrivateSubnets&4AZCondition
-          - !Ref 'PrivateSubnet4ARouteTable'
-          - !Ref 'AWS::NoValue'
-        - !If
-          - AdditionalPrivateSubnetsCondition
-          - !Ref 'PrivateSubnet1BRouteTable'
-          - !Ref 'AWS::NoValue'
-        - !If
-          - AdditionalPrivateSubnetsCondition
-          - !Ref 'PrivateSubnet2BRouteTable'
-          - !Ref 'AWS::NoValue'
-        - !If
-          - AdditionalPrivateSubnets&3AZCondition
-          - !Ref 'PrivateSubnet3BRouteTable'
-          - !Ref 'AWS::NoValue'
-        - !If
-          - AdditionalPrivateSubnets&4AZCondition
-          - !Ref 'PrivateSubnet4BRouteTable'
-          - !Ref 'AWS::NoValue'
+        - !If [PrivateSubnets&3AZCondition, !Ref 'PrivateSubnet3ARouteTable', !Ref 'AWS::NoValue']
+        - !If [PrivateSubnets&4AZCondition, !Ref 'PrivateSubnet4ARouteTable', !Ref 'AWS::NoValue']
+        - !If [AdditionalPrivateSubnetsCondition, !Ref 'PrivateSubnet1BRouteTable', !Ref 'AWS::NoValue']
+        - !If [AdditionalPrivateSubnetsCondition, !Ref 'PrivateSubnet2BRouteTable', !Ref 'AWS::NoValue']
+        - !If [AdditionalPrivateSubnets&3AZCondition, !Ref 'PrivateSubnet3BRouteTable', !Ref 'AWS::NoValue']
+        - !If [AdditionalPrivateSubnets&4AZCondition, !Ref 'PrivateSubnet4BRouteTable', !Ref 'AWS::NoValue']
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.s3'
       VpcId: !Ref 'VPC'
+  VPCFlowLogsRole:
+    Condition: VPCFlowLogsToCloudWatchCondition
+    Type: AWS::IAM::Role
+    Properties:
+      Description: Rights to Publish VPC Flow Logs to CloudWatch Logs
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service:
+                - vpc-flow-logs.amazonaws.com
+      Path: /
+      Policies:
+        - PolicyName: CloudWatchLogGroup
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:DescribeLogGroups
+                  - logs:DescribeLogStreams
+                Resource: !GetAtt VPCFlowLogsLogGroup.Arn
+  VPCFlowLogsLogGroup:
+    Condition: VPCFlowLogsToCloudWatchCondition
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: !Ref VPCFlowLogsLogGroupRetention
+  VPCFlowLogstoCloudWatch:
+    Condition: VPCFlowLogsToCloudWatchCondition
+    Type: AWS::EC2::FlowLog
+    Properties:
+      LogDestinationType: cloud-watch-logs
+      LogGroupName: !Ref VPCFlowLogsLogGroup
+      DeliverLogsPermissionArn: !GetAtt VPCFlowLogsRole.Arn
+      LogFormat: !Ref VPCFlowLogsLogFormat
+      MaxAggregationInterval: !Ref VPCFlowLogsMaxAggregationInterval
+      ResourceId: !Ref VPC
+      ResourceType: VPC
+      TrafficType: !Ref VPCFlowLogsTrafficType
+      Tags:
+        - Key: Name
+          Value: VPC Flow Logs CloudWatch
 Outputs:
   NAT1EIP:
-    Condition: NATGatewaysCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnetsCondition
     Description: NAT 1 IP address
     Value: !Ref 'NAT1EIP'
     Export:
       Name: !Sub '${AWS::StackName}-NAT1EIP'
   NAT2EIP:
-    Condition: NATGatewaysCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnetsCondition
     Description: NAT 2 IP address
     Value: !Ref 'NAT2EIP'
     Export:
       Name: !Sub '${AWS::StackName}-NAT2EIP'
   NAT3EIP:
-    Condition: NATGateways&3AZCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnets&3AZCondition
     Description: NAT 3 IP address
     Value: !Ref 'NAT3EIP'
     Export:
       Name: !Sub '${AWS::StackName}-NAT3EIP'
   NAT4EIP:
-    Condition: NATGateways&4AZCondition
+    Condition: NATGateways&PublicSubnets&PrivateSubnets&4AZCondition
     Description: NAT 4 IP address
     Value: !Ref 'NAT4EIP'
     Export:
@@ -1605,6 +1353,12 @@ Outputs:
     Value: !Ref 'PrivateSubnet1A'
     Export:
       Name: !Sub '${AWS::StackName}-PrivateSubnet1AID'
+  PrivateSubnet1ARouteTable:
+    Condition: PrivateSubnetsCondition
+    Value: !Ref 'PrivateSubnet1ARouteTable'
+    Description: Private subnet 1A route table
+    Export:
+      Name: !Sub '${AWS::StackName}-PrivateSubnet1ARouteTable'
   PrivateSubnet1BCIDR:
     Condition: AdditionalPrivateSubnetsCondition
     Description: Private subnet 1B CIDR in Availability Zone 1
@@ -1617,6 +1371,12 @@ Outputs:
     Value: !Ref 'PrivateSubnet1B'
     Export:
       Name: !Sub '${AWS::StackName}-PrivateSubnet1BID'
+  PrivateSubnet1BRouteTable:
+    Condition: AdditionalPrivateSubnetsCondition
+    Value: !Ref 'PrivateSubnet1BRouteTable'
+    Description: Private subnet 1B route table
+    Export:
+      Name: !Sub '${AWS::StackName}-PrivateSubnet1BRouteTable'
   PrivateSubnet2ACIDR:
     Condition: PrivateSubnetsCondition
     Description: Private subnet 2A CIDR in Availability Zone 2
@@ -1629,6 +1389,12 @@ Outputs:
     Value: !Ref 'PrivateSubnet2A'
     Export:
       Name: !Sub '${AWS::StackName}-PrivateSubnet2AID'
+  PrivateSubnet2ARouteTable:
+    Condition: PrivateSubnetsCondition
+    Value: !Ref 'PrivateSubnet2ARouteTable'
+    Description: Private subnet 2A route table
+    Export:
+      Name: !Sub '${AWS::StackName}-PrivateSubnet2ARouteTable'
   PrivateSubnet2BCIDR:
     Condition: AdditionalPrivateSubnetsCondition
     Description: Private subnet 2B CIDR in Availability Zone 2
@@ -1641,6 +1407,12 @@ Outputs:
     Value: !Ref 'PrivateSubnet2B'
     Export:
       Name: !Sub '${AWS::StackName}-PrivateSubnet2BID'
+  PrivateSubnet2BRouteTable:
+    Condition: AdditionalPrivateSubnetsCondition
+    Value: !Ref 'PrivateSubnet2BRouteTable'
+    Description: Private subnet 2B route table
+    Export:
+      Name: !Sub '${AWS::StackName}-PrivateSubnet2BRouteTable'
   PrivateSubnet3ACIDR:
     Condition: PrivateSubnets&3AZCondition
     Description: Private subnet 3A CIDR in Availability Zone 3
@@ -1653,6 +1425,12 @@ Outputs:
     Value: !Ref 'PrivateSubnet3A'
     Export:
       Name: !Sub '${AWS::StackName}-PrivateSubnet3AID'
+  PrivateSubnet3ARouteTable:
+    Condition: PrivateSubnets&3AZCondition
+    Value: !Ref 'PrivateSubnet3ARouteTable'
+    Description: Private subnet 3A route table
+    Export:
+      Name: !Sub '${AWS::StackName}-PrivateSubnet3ARouteTable'
   PrivateSubnet3BCIDR:
     Condition: AdditionalPrivateSubnets&3AZCondition
     Description: Private subnet 3B CIDR in Availability Zone 3
@@ -1665,6 +1443,12 @@ Outputs:
     Value: !Ref 'PrivateSubnet3B'
     Export:
       Name: !Sub '${AWS::StackName}-PrivateSubnet3BID'
+  PrivateSubnet3BRouteTable:
+    Condition: AdditionalPrivateSubnets&3AZCondition
+    Description: Private subnet 3B route table
+    Value: !Ref 'PrivateSubnet3BRouteTable'
+    Export:
+      Name: !Sub '${AWS::StackName}-PrivateSubnet3BRouteTable'
   PrivateSubnet4ACIDR:
     Condition: PrivateSubnets&4AZCondition
     Description: Private subnet 4A CIDR in Availability Zone 4
@@ -1677,6 +1461,12 @@ Outputs:
     Value: !Ref 'PrivateSubnet4A'
     Export:
       Name: !Sub '${AWS::StackName}-PrivateSubnet4AID'
+  PrivateSubnet4ARouteTable:
+    Condition: PrivateSubnets&4AZCondition
+    Description: Private subnet 4A route table
+    Value: !Ref 'PrivateSubnet4ARouteTable'
+    Export:
+      Name: !Sub '${AWS::StackName}-PrivateSubnet4ARouteTable'
   PrivateSubnet4BCIDR:
     Condition: AdditionalPrivateSubnets&4AZCondition
     Description: Private subnet 4B CIDR in Availability Zone 4
@@ -1689,6 +1479,12 @@ Outputs:
     Value: !Ref 'PrivateSubnet4B'
     Export:
       Name: !Sub '${AWS::StackName}-PrivateSubnet4BID'
+  PrivateSubnet4BRouteTable:
+    Condition: AdditionalPrivateSubnets&4AZCondition
+    Description: Private subnet 4B route table
+    Value: !Ref 'PrivateSubnet4BRouteTable'
+    Export:
+      Name: !Sub '${AWS::StackName}-PrivateSubnet4BRouteTable'
   PublicSubnet1CIDR:
     Condition: PublicSubnetsCondition
     Description: Public subnet 1 CIDR in Availability Zone 1
@@ -1737,73 +1533,25 @@ Outputs:
     Value: !Ref 'PublicSubnet4'
     Export:
       Name: !Sub '${AWS::StackName}-PublicSubnet4ID'
+  PublicSubnetRouteTable:
+    Condition: PublicSubnetsCondition
+    Description: Public subnet route table
+    Value: !Ref 'PublicSubnetRouteTable'
+    Export:
+      Name: !Sub '${AWS::StackName}-PublicSubnetRouteTable'
   S3VPCEndpoint:
     Condition: PrivateSubnetsCondition
     Description: S3 VPC Endpoint
     Value: !Ref 'S3VPCEndpoint'
     Export:
       Name: !Sub '${AWS::StackName}-S3VPCEndpoint'
-  PrivateSubnet1ARouteTable:
-    Condition: PrivateSubnetsCondition
-    Value: !Ref 'PrivateSubnet1ARouteTable'
-    Description: Private subnet 1A route table
-    Export:
-      Name: !Sub '${AWS::StackName}-PrivateSubnet1ARouteTable'
-  PrivateSubnet1BRouteTable:
-    Condition: AdditionalPrivateSubnetsCondition
-    Value: !Ref 'PrivateSubnet1BRouteTable'
-    Description: Private subnet 1B route table
-    Export:
-      Name: !Sub '${AWS::StackName}-PrivateSubnet1BRouteTable'
-  PrivateSubnet2ARouteTable:
-    Condition: PrivateSubnetsCondition
-    Value: !Ref 'PrivateSubnet2ARouteTable'
-    Description: Private subnet 2A route table
-    Export:
-      Name: !Sub '${AWS::StackName}-PrivateSubnet2ARouteTable'
-  PrivateSubnet2BRouteTable:
-    Condition: AdditionalPrivateSubnetsCondition
-    Value: !Ref 'PrivateSubnet2BRouteTable'
-    Description: Private subnet 2B route table
-    Export:
-      Name: !Sub '${AWS::StackName}-PrivateSubnet2BRouteTable'
-  PrivateSubnet3ARouteTable:
-    Condition: PrivateSubnets&3AZCondition
-    Value: !Ref 'PrivateSubnet3ARouteTable'
-    Description: Private subnet 3A route table
-    Export:
-      Name: !Sub '${AWS::StackName}-PrivateSubnet3ARouteTable'
-  PrivateSubnet3BRouteTable:
-    Condition: AdditionalPrivateSubnets&3AZCondition
-    Value: !Ref 'PrivateSubnet3BRouteTable'
-    Description: Private subnet 3B route table
-    Export:
-      Name: !Sub '${AWS::StackName}-PrivateSubnet3BRouteTable'
-  PrivateSubnet4ARouteTable:
-    Condition: PrivateSubnets&4AZCondition
-    Value: !Ref 'PrivateSubnet4ARouteTable'
-    Description: Private subnet 4A route table
-    Export:
-      Name: !Sub '${AWS::StackName}-PrivateSubnet4ARouteTable'
-  PrivateSubnet4BRouteTable:
-    Condition: AdditionalPrivateSubnets&4AZCondition
-    Value: !Ref 'PrivateSubnet4BRouteTable'
-    Description: Private subnet 4B route table
-    Export:
-      Name: !Sub '${AWS::StackName}-PrivateSubnet4BRouteTable'
-  PublicSubnetRouteTable:
-    Condition: PublicSubnetsCondition
-    Value: !Ref 'PublicSubnetRouteTable'
-    Description: Public subnet route table
-    Export:
-      Name: !Sub '${AWS::StackName}-PublicSubnetRouteTable'
   VPCCIDR:
-    Value: !Ref 'VPCCIDR'
     Description: VPC CIDR
+    Value: !Ref 'VPCCIDR'
     Export:
       Name: !Sub '${AWS::StackName}-VPCCIDR'
   VPCID:
-    Value: !Ref 'VPC'
     Description: VPC ID
+    Value: !Ref 'VPC'
     Export:
       Name: !Sub '${AWS::StackName}-VPCID'


### PR DESCRIPTION
*Description of changes:*
- Formatting Updates
  - changed to single quotes per AWS Quick Start Builder Guide
  - simplify functions into 1 lines
  - fixed the order of some elements.
- Other
  - updated template description & `.adoc` documentation files accordingly to not reference NAT instances.
  - removed `GovCloudCondition` as its not being used
- Tag Updates
  - added `Name` and `StackName` tags to `DHCPOptions` resource
  - added `Name` tags to `EIP` resources
  - added `Name` tags to `NATGateway` resources
- Created new NATGateway conditions below (and remove old NATGateway conditions no longer needed) to address `taskcat` failing due to `linting failed with errors` (otherwise taskcat only works   when running `taskcat -l` disabling the linting checks)
  - `NATGateways&PublicSubnets&PrivateSubnetsCondition`
  - `NATGateways&PublicSubnets&PrivateSubnets&3AZCondition`
  - `NATGateways&PublicSubnets&PrivateSubnets&4AZCondition`
- In `.taskcat.yml`, commented the project regions `cn-north-1` and `cn-northwest-1`, since they aren't being used in any of the `tests`, and this  solves the error you get if these regions aren't enabled in the AWS account you are testing with. 
  - FYI, the error you would get, if region is not enabled is shown below:
  `ClientError An error occurred (AuthFailure) when calling the DescribeAvailabilityZones operation: AWS was not able to validate the provided access credentials`
- Created a `.gitignore` (to exclude files related to taskcat testing)
- Added the option to `Create VPC Flow Logs for the VPC to publish to CloudWatch`
  - set the Default to `false`, so no VPC Flow Logs are created.
  - parameterized the different VPC Flow log options, so its easy to customize.

*Taskcat Output:*
[NoVPCFlowLogsTest.zip](https://github.com/aws-quickstart/quickstart-aws-vpc/files/5922424/NoVPCFlowLogsTest.zip)
[VPCFlowLogsTest.zip](https://github.com/aws-quickstart/quickstart-aws-vpc/files/5922426/VPCFlowLogsTest.zip)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
