### PR TITLE
KMSKey Support for CloudWatch Logs & Note "deprecating json template"

### DIFF
--- a/templates/aws-vpc.template
+++ b/templates/aws-vpc.template
@@ -1,6 +1,11 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "This template creates a Multi-AZ, multi-subnet VPC infrastructure with managed NAT gateways in the public subnet for each Availability Zone. You can also create additional private subnets with dedicated custom network access control lists (ACLs). If you deploy the Quick Start in a region that doesn't support NAT gateways, NAT instances are deployed instead. **WARNING** This template creates AWS resources. You will be billed for the AWS resources used if you create a stack from this template. (qs-1qnnspaap)",
+    "Description":
+        "DEPRECATED: This template has been deprecated in favor of the 'aws-vpc.template.yaml`, and is no longer being maintained.  This template
+        creates a Multi-AZ, multi-subnet VPC infrastructure with managed NAT gateways in the public subnet for each Availability Zone. You can also
+        create additional private subnets with dedicated custom network access control lists (ACLs). If you deploy the Quick Start in a region that
+        doesn't support NAT gateways, NAT instances are deployed instead. **WARNING** This template creates AWS resources. You will be billed for the
+        AWS resources used if you create a stack from this template. (qs-1qnnspaap)",
     "Metadata": {
         "AWS::CloudFormation::Interface": {
             "ParameterGroups": [

--- a/templates/aws-vpc.template.yaml
+++ b/templates/aws-vpc.template.yaml
@@ -62,6 +62,7 @@ Metadata:
           - VPCFlowLogsLogGroupRetention
           - VPCFlowLogsMaxAggregationInterval
           - VPCFlowLogsTrafficType
+          - VPCFlowLogsCloudWatchKMSKey
       - Label:
           default: Deprecated - NAT Instance Configuration
         Parameters:
@@ -130,6 +131,8 @@ Metadata:
         default: Tag for Public Subnets
       VPCCIDR:
         default: VPC CIDR
+      VPCFlowLogsCloudWatchKMSKey:
+        default: CloudWatch Logs KMS Key for VPC flow logs
       VPCFlowLogsLogFormat:
         default: VPC Flow Logs - Log Format
       VPCFlowLogsLogGroupRetention:
@@ -340,6 +343,14 @@ Parameters:
     Default: 10.0.0.0/16
     Description: CIDR block for the VPC
     Type: String
+  VPCFlowLogsCloudWatchKMSKey:
+    AllowedPattern: '^$|^arn:(aws[a-zA-Z-]*)?:kms:[a-z0-9-]+:\d{12}:key\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'
+    ConstraintDescription: 'Key ARN example:  arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab'
+    Default: ''
+    Description:
+      (Optional) KMS Key ARN to use for encrypting the VPC flow logs data. If empty, encryption is enabled with CloudWatch Logs managing the
+      server-side encryption keys.
+    Type: String
   VPCFlowLogsLogFormat:
     AllowedPattern: '^(\$\{[a-z-]+\})$|^((\$\{[a-z-]+\} )*\$\{[a-z-]+\})$'
     Default:
@@ -457,6 +468,7 @@ Conditions:
   PublicSubnetTag1Condition: !Not [!Equals [!Ref 'PublicSubnetTag1', '']]
   PublicSubnetTag2Condition: !Not [!Equals [!Ref 'PublicSubnetTag2', '']]
   PublicSubnetTag3Condition: !Not [!Equals [!Ref 'PublicSubnetTag3', '']]
+  VPCFlowLogsCloudWatchKMSKeyCondition: !Not [!Equals [!Ref VPCFlowLogsCloudWatchKMSKey, '']]
   VPCFlowLogsToCloudWatchCondition: !Equals [!Ref 'CreateVPCFlowLogsToCloudWatch', 'true']
 Resources:
   DHCPOptions:
@@ -1301,7 +1313,11 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: !Ref VPCFlowLogsLogGroupRetention
-  VPCFlowLogstoCloudWatch:
+      KmsKeyId: !If
+        - VPCFlowLogsCloudWatchKMSKeyCondition
+        - !Ref VPCFlowLogsCloudWatchKMSKey
+        - !Ref AWS::NoValue
+  VPCFlowLogsToCloudWatch:
     Condition: VPCFlowLogsToCloudWatchCondition
     Type: AWS::EC2::FlowLog
     Properties:


### PR DESCRIPTION
*Description of changes:*
- By default, a CloudWatch Logs log group data is encrypted with CloudWatch Logs managing the server-side encryption keys.
  - Added an Optional parameter for a KMS Key, if applied, server-side encryption is done with the specified [KMS CMK](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html).
- Added note in the template description of `aws-vpc.template`, stating:
  - `DEPRECATED: This template has been deprecated in favor of the 'aws-vpc.template.yaml', and is no longer being maintained.`

*Taskcat Output:*
[TaskcatResults.zip](https://github.com/aws-quickstart/quickstart-aws-vpc/files/5956098/TaskcatResults.zip)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
